### PR TITLE
Modular renderer

### DIFF
--- a/example/TestLevel.hpp
+++ b/example/TestLevel.hpp
@@ -20,7 +20,7 @@ public:
 
 	void atRefresh()
 	{
-		AnnDebug() << "Sinbad position is : " << getPosition();
+		//AnnDebug() << "Sinbad position is : " << getPosition();
 	}
 };
 
@@ -71,7 +71,7 @@ public:
 
 	void runLogic()
 	{
-		AnnDebug() << "Player position is : " << AnnGetPlayer()->getPosition();
+		//AnnDebug() << "Player position is : " << AnnGetPlayer()->getPosition();
 	}
 
 private:

--- a/example/TestLevel.hpp
+++ b/example/TestLevel.hpp
@@ -20,7 +20,7 @@ public:
 
 	void atRefresh()
 	{
-																													   
+		AnnDebug() << "Sinbad position is : " << getPosition();
 	}
 };
 
@@ -70,7 +70,9 @@ public:
 	}
 
 	void runLogic()
-	{}
+	{
+		AnnDebug() << "Player position is : " << AnnGetPlayer()->getPosition();
+	}
 
 private:
 };

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -91,7 +91,7 @@ AnnMain()
 	AnnGetResourceManager()->initResources();
 
 	//SetUp Oculus system	
-	AnnGetEngine()->oculusInit();
+	AnnGetEngine()->VrInit();
 	AnnGetSceneryManager()->setNearClippingDistance(0.20f);
 	
 	//Init some player body parameters

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -76,6 +76,40 @@ public:
 	{
 		AnnDebug() << "TriggerEvent contact status : " << e.getContactStatus() << " from " << e.getSender();
 	}
+
+	void testFileIO()
+	{
+		auto testFile = AnnGetFileSystemManager()->crateSaveFileDataObject("test");
+		testFile->setValue("KEY0", "Thing");
+		testFile->setValue("KEY1", "otherThing");
+		testFile->setValue("lives", 10);
+		testFile->setValue("PI", 3.14f);
+		testFile->setValue("pos", AnnVect3(2.5, 4.8, Ogre::Math::HALF_PI));
+		testFile->setValue("orient", AnnQuaternion(Ogre::Radian(Ogre::Math::HALF_PI), AnnVect3(.5, .5, .5)));
+
+		AnnFileWriter* writer(AnnGetFileSystemManager()->getFileWriter());
+		writer->write(testFile);
+
+		AnnFileReader* reader(AnnGetFileSystemManager()->getFileReader());
+		auto data = reader->read("test");
+
+		AnnDebug() << "KEY0 val : " << data->getValue("KEY0");
+		AnnDebug() << "KEY1 val : " << data->getValue("KEY1");
+
+		MySaveTest tester(data);
+		tester.extract();
+		AnnDebug() << "stored vector value : " << tester.getPosition();
+		AnnDebug() << "stored quaternion value : " << tester.getOrientation();
+		AnnDebug() << "stored pi value : " << tester.getPi();
+		AnnDebug() << "stored lives value : " << tester.getLives();
+
+	}
+
+	void KeyEvent(AnnKeyEvent e)
+	{
+		if (e.isPressed() && e.getKey() == KeyCode::h)
+			testFileIO();
+	}
 };
 
 AnnMain()
@@ -103,53 +137,18 @@ AnnMain()
 	AnnAbstractLevel* level = new TestLevel();
 	AnnSplashLevel* splash = new AnnSplashLevel("splash.png", level, 7.1f);
 	splash->setBGM("media/AnnSplash.ogg");
-
-	AnnGetEngine()->getLevelManager()->addLevel(splash);
-	AnnGetEngine()->getLevelManager()->addLevel(level);
-	//AnnGetEngine()->getLevelManager()->jumpToFirstLevel();		//Jump to that level 
-	//AnnGetEngine()->getLevelManager()->jump(splash);
-	AnnGetEngine()->getLevelManager()->jump(level);
 	
 	AnnGetEventManager()->useDefaultEventListener();
 	AnnGetEngine()->resetOculusOrientation();
 	AnnGetEngine()->getEventManager()->addListener(new DebugListener);
 	demoTimer = AnnGetEngine()->getEventManager()->fireTimer(10);
-	
-	AnnLightObject* light = AnnGetGameObjectManager()->createLightObject(); 
-	AnnGetGameObjectManager()->destroyLightObject(light);
 
-	auto testFile = AnnGetFileSystemManager()->crateSaveFileDataObject("test");
-	testFile->setValue("KEY0", "Thing");
-	testFile->setValue("KEY1", "otherThing");
-	testFile->setValue("lives", 10);
-	testFile->setValue("PI", 3.14f);
-	testFile->setValue("pos", AnnVect3(2.5, 4.8, Ogre::Math::HALF_PI));
-	testFile->setValue("orient", AnnQuaternion(Ogre::Radian(Ogre::Math::HALF_PI), AnnVect3(.5,.5,.5)));
+	AnnGetEngine()->getLevelManager()->addLevel(splash);
+	AnnGetEngine()->getLevelManager()->addLevel(level);
+	AnnGetEngine()->getLevelManager()->jumpToFirstLevel();
 
-	AnnFileWriter* writer(AnnGetFileSystemManager()->getFileWriter());
-	writer->write(testFile);
-
-	AnnFileReader* reader(AnnGetFileSystemManager()->getFileReader());
-	auto data = reader->read("test");
-	
-	AnnDebug() << "KEY0 val : " << data->getValue("KEY0");
-	AnnDebug() << "KEY1 val : " << data->getValue("KEY1");
-
-	MySaveTest tester(data);
-	tester.extract();
-	AnnDebug() << "stored vector value : " << tester.getPosition();
-	AnnDebug() << "stored quaternion value : " << tester.getOrientation();
-	AnnDebug() << "stored pi value : " << tester.getPi();
-	AnnDebug() << "stored lives value : " << tester.getLives();
 
 	AnnDebug() << "Starting the render loop";
-	
-	auto sinbad(AnnGetGameObjectManager()->createGameObject("Sinbad.mesh"));
-	sinbad->setPosition(100, 100, 100);
-	sinbad->setUpPhysics();
-	AnnGetGameObjectManager()->createLightObject()->setPosition(AnnVect3(50, 50, 50));
-	AnnGetGameObjectManager()->createTriggerObject()->setPosition(100, 100, 100);
-
 	do	
 	{
 		if(AnnGetEngine()->isKeyDown(OIS::KC_Q))

--- a/include/AnnEngine.hpp
+++ b/include/AnnEngine.hpp
@@ -66,6 +66,8 @@
 #define AnnGetGameObjectManager() AnnGetEngine()->getGameObjectManager()
 ///Get SceneryManager
 #define AnnGetSceneryManager() AnnGetEngine()->getSceneryManager()
+///GEt VRREnderer
+#define AnnGetVRRenderer() AnnGetEngine()->getVRRenderer()
 
 namespace Annwvyn
 {
@@ -146,6 +148,8 @@ namespace Annwvyn
 
 		///Get the SceneryManager
 		AnnSceneryManager* getSceneryManager();
+
+		OgreVRRender* getVRRenderer();
 
 		
 		/////////////////////////////////////////////////////////////////////////////////////////////////////SUBSYSTEMS

--- a/include/AnnEngine.hpp
+++ b/include/AnnEngine.hpp
@@ -152,7 +152,7 @@ namespace Annwvyn
 		////////////////////////////////////////////////////////////////////////////////////////////////TO CALL AT INIT
 		
 		///Init OgreOculus stuff
-		void oculusInit(); //oculus
+		void VrInit(); //oculus
 
 	    ///Init the physics model
 		void initPlayerPhysics(); //physics on player
@@ -171,9 +171,6 @@ namespace Annwvyn
 
 		///This start the reder loop. This also calls objects "atRefresh" and current level "runLogic" methods each frame
 		void startGameplayLoop();
-
-		///Get a pose information object
-		OgrePose getPoseFromOOR();
 
 		///Reset the Rift Orientation
 		void resetOculusOrientation();///Gameplay... but engine related function. 
@@ -195,6 +192,7 @@ namespace Annwvyn
 
 		///Get elapsed time between two frames in seconds
 		double getFrameTime();
+		OgrePose getHmdPose();
 		///////////////////////////////////////////////////////////////////////////////////////////////TIMER MANAGEMENT
 
 	private:
@@ -228,7 +226,7 @@ namespace Annwvyn
 		Ogre::SceneNode* povNode;
 
 		///Oculus oculus;
-		OgreOculusRender* renderer;
+		OgreVRRender* renderer;
 
 		///Elapsed time between 2 frames
 		double updateTime;

--- a/include/AnnGameObjectManager.hpp
+++ b/include/AnnGameObjectManager.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef ANN_GAME_OBJECT_MANAGER
+#define ANN_GAME_OBJECT_MANAGER
 #include "systemMacro.h"
 
 #include "AnnGameObject.hpp"
@@ -55,3 +56,5 @@ namespace Annwvyn
 
 	};
 }
+
+#endif

--- a/include/AnnResourceManager.hpp
+++ b/include/AnnResourceManager.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef ANN_RESOURCE_MANAGER
+#define ANN_RESOURCE_MANAGER
+
 #include "systemMacro.h"
 #include "OgreResourceGroupManager.h"
 #include "AnnSubsystem.hpp"
@@ -32,3 +34,5 @@ namespace Annwvyn
 
 	};
 }
+
+#endif

--- a/include/AnnSceneryManager.hpp
+++ b/include/AnnSceneryManager.hpp
@@ -3,14 +3,14 @@
 #include "AnnSubsystem.hpp"
 #include "OgreSceneManager.h"
 #include "AnnTypes.h"
-#include "OgreOculusRender.hpp"
+#include "OgreVRRender.hpp"
 
 namespace Annwvyn
 {
 	class DLL AnnSceneryManager : public AnnSubSystem
 	{
 	public:
-		AnnSceneryManager(OgreOculusRender* renderer);
+		AnnSceneryManager(OgreVRRender* renderer);
 		bool needUpdate() { return false; }
 
 
@@ -54,6 +54,6 @@ namespace Annwvyn
 
 	private:
 		Ogre::SceneManager* smgr;
-		OgreOculusRender* renderer;
+		OgreVRRender* renderer;
 	};
 }

--- a/include/AnnSceneryManager.hpp
+++ b/include/AnnSceneryManager.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef	ANN_SCENERY_MANAGER
+#define ANN_SCENERY_MANAGER
+
 #include "systemMacro.h"
 #include "AnnSubsystem.hpp"
 #include "OgreSceneManager.h"
@@ -10,7 +12,11 @@ namespace Annwvyn
 	class DLL AnnSceneryManager : public AnnSubSystem
 	{
 	public:
+
+		///Construct the AnnSceneryManager
 		AnnSceneryManager(OgreVRRender* renderer);
+
+		///This subsystem doesn't need to be updated
 		bool needUpdate() { return false; }
 
 
@@ -53,7 +59,12 @@ namespace Annwvyn
 		void setNearClippingDistance(float distance);
 
 	private:
+		///Scene manager created by the VR renderer
 		Ogre::SceneManager* smgr;
+
+		///Pointer to the VR renderer
 		OgreVRRender* renderer;
 	};
 }
+
+#endif

--- a/include/OgreOculusRender.hpp
+++ b/include/OgreOculusRender.hpp
@@ -125,6 +125,10 @@ class DLL OgreOculusRender : public OgreVRRender
 		///Init the rendering pipeline
 		void initPipeline();
 
+		bool usesCustomAudioDevice();
+
+		std::string getAudioDeviceIdentifierSubString();
+
     private://Methods
 		///Set the Fov for the monoscopic view
 		void setMonoFov(float degreeFov);

--- a/include/OgreOculusRender.hpp
+++ b/include/OgreOculusRender.hpp
@@ -218,9 +218,6 @@ class DLL OgreOculusRender : public OgreVRRender
 		///Orientation of the rift at the last frame
         Ogre::Quaternion lastOculusOrientation;
 
-		///Pose to be returned
-		OgrePose returnPose;
-
 		///Texture unit state of the debug plane
 		static Ogre::TextureUnitState* debugTexturePlane;
 

--- a/include/OgreOculusRender.hpp
+++ b/include/OgreOculusRender.hpp
@@ -56,8 +56,13 @@ class DLL OgreOculusRender : public OgreVRRender
 		///Class destructor
         ~OgreOculusRender();
 
+		///Oculus runtime hint to quit
 		bool shouldQuit();
+		
+		///Oculus runtim hit to recenter
 		bool shouldRecenter();
+
+		///App not visible inside Oculus
 		bool isVisibleInHmd();
 
 		///Cycle through all Oculus Performance HUD available
@@ -71,8 +76,9 @@ class DLL OgreOculusRender : public OgreVRRender
 
 		///Set the near Z clipping plane distance from the POV. Used to calculate Projections matricies
 		void setCamerasNearClippingDistance(float distance = 0.15f);
-		void setCameraFarClippingDistance(float distance);
 
+		///Set the far Z clipping plan distance from the POV. Used to calculate Projection matrices
+		void setCameraFarClippingDistance(float distance = 4000.0f);
 
 		///Start Oculus and Ogre libraries.
         void initVrHmd();
@@ -125,28 +131,30 @@ class DLL OgreOculusRender : public OgreVRRender
 		///Init the rendering pipeline
 		void initPipeline();
 
+		///The Oculus Rift has integrated audio
 		bool usesCustomAudioDevice();
 
+		///The Oculus Rift integrated audio playback device will have "something (Rift Audio)" as a name
 		std::string getAudioDeviceIdentifierSubString();
 
-    private://Methods
+	private:
+		///Pointer to the renderer itself, recasted as this class, not the parent
+		static OgreOculusRender* OculusSelf;
+
 		///Set the Fov for the monoscopic view
 		void setMonoFov(float degreeFov);
-
-	private://Attributes
-		static OgreOculusRender* OculusSelf;
+		
 		///Save content of the RenderTexture to the specified file. This verry slow operation is only usefull for debuging the renderer itself
         void debugSaveToFile(const char path[]);
 		
 		///Object for getting informations from the Oculus Rift
         OculusInterface* Oculus; 
 
-
 		///Ogre Scene Manager
         Ogre::SceneManager* debugSmgr;	
 
-		///Stereoscopic camera array. Indexes are "left" and "right" + debug view cam
-        Ogre::Camera* eyeCameras[2], * debugCam, * monoCam; 
+		///Additional camera objects
+        Ogre::Camera* debugCam, * monoCam; 
 		
 		///Nodes for the debug scene
 		Ogre::SceneNode* debugCamNode, * debugPlaneNode; 

--- a/include/OgreVRRender.hpp
+++ b/include/OgreVRRender.hpp
@@ -50,7 +50,8 @@ public:
 
 	///Init the VR client library
 	virtual void initVrHmd() = 0;
-	 
+	
+	///Init the VR client rendering
 	virtual void initClientHmdRendering() =0;
 
 	///If true, you should cleanly quit the program from now
@@ -93,23 +94,43 @@ public:
 	OgrePose returnPose;
 
 protected:
+	///Singleton pointer
+	static OgreVRRender* self;
+
+	///SceneManager of the VR world
 	Ogre::SceneManager* smgr;
+
+	///Ogre root object
 	Ogre::Root* root;
+
+	///Render window. VR isn't drawn to this window. A window is mandatory to init the RenderSystem. 
 	Ogre::RenderWindow* window;
+
+	///Update Time
 	double updateTime;
 
+	///Distance between eyeCamera and nearClippingDistance
 	Ogre::Real nearClippingDistance;
+
+	///Distance between eyeCamera and farClippingDistance
 	Ogre::Real farClippingDistance;
 
+	///Position of the head
 	Ogre::Vector3 headPosition;
+
+	///Orientation of the head
 	Ogre::Quaternion headOrientation;
 
+	///Name of the window
 	std::string name;
 
+	///Node that represent the head base. Move this in 3D to move the viewpoint
 	Ogre::SceneNode* headNode;
 
-	static OgreVRRender* self;
 	///background color of viewports
 	Ogre::ColourValue backgroundColor;
+
+	///Cameras that have to be put where the user's eye is
+	Ogre::Camera* eyeCameras[2];
 
 };

--- a/include/OgreVRRender.hpp
+++ b/include/OgreVRRender.hpp
@@ -83,6 +83,12 @@ public:
 	///Set the VR cameras far clipping plane distance
 	virtual void setCameraFarClippingDistance(float distance) = 0;
 
+	///(Optional) return true if audio has to come out from a specific audio device
+	virtual bool usesCustomAudioDevice() { return false; }
+
+	///(Optionalà retrun the sub string to search on the audio device list to get the correct one
+	virtual std::string getAudioDeviceIdentifierSubString() { return std::string(""); }
+
 	///The current position of the head center defined by the client library projected in World Space
 	OgrePose returnPose;
 

--- a/include/OgreVRRender.hpp
+++ b/include/OgreVRRender.hpp
@@ -1,11 +1,12 @@
-#pragma once
+#ifndef OGREVRRENDER
+#define OGREVRRENDER
+
 #include "systemMacro.h"
 
 #include <string>
 
 #include <Ogre.h>
 #include "AnnErrorCode.hpp"
-
 
 
 ///A pose refer to the combinaison of a position and an orientation. 
@@ -21,7 +22,10 @@ struct OgrePose
 class DLL OgreVRRender
 {
 public:
+	///Construct VR Renderer
 	OgreVRRender(std::string windowName);
+
+	///Destruct VR Renderer
 	virtual ~OgreVRRender();
 
 	///Get the scene manager of the virtual world
@@ -134,3 +138,5 @@ protected:
 	Ogre::Camera* eyeCameras[2];
 
 };
+
+#endif

--- a/include/OgreVRRender.hpp
+++ b/include/OgreVRRender.hpp
@@ -1,0 +1,109 @@
+#pragma once
+#include "systemMacro.h"
+
+#include <string>
+
+#include <Ogre.h>
+#include "AnnErrorCode.hpp"
+
+
+
+///A pose refer to the combinaison of a position and an orientation. 
+///It permit to define the placement of an object with 6DOF
+struct OgrePose
+{
+	///A 3D vector representing a position
+	Ogre::Vector3 position;
+	///A quaternion representiong an orientation
+	Ogre::Quaternion orientation;
+};
+
+class DLL OgreVRRender
+{
+public:
+	OgreVRRender(std::string windowName);
+	virtual ~OgreVRRender();
+
+	///Get the scene manager of the virtual world
+	Ogre::SceneManager* getSceneManager();
+
+	///Get the Ogre::Root object 
+	Ogre::Root* getRoot();
+
+	///Get the RenderWidow that should display a debug render the VR view
+	Ogre::RenderWindow* getWindow();
+
+	///Get the node that is the player's head anchor point
+	Ogre::SceneNode* getCameraInformationNode();
+
+	///Get Ogre's internal timer
+	Ogre::Timer* getTimer();
+
+	///Get frame update time from the VR renderer
+	double getUpdateTime();
+
+	///Init Ogre, please provie the name of the output log file
+	void initOgreRoot(std::string loggerName);
+
+	///Init the VR rendering pipeline
+	virtual void initPipeline() = 0;
+
+	///Init the VR client library
+	virtual void initVrHmd() = 0;
+	 
+	virtual void initClientHmdRendering() =0;
+
+	///If true, you should cleanly quit the program from now
+	virtual bool shouldQuit() = 0;
+
+	///If true you should use the current position as the new center of tracking
+	virtual bool shouldRecenter() = 0;
+
+	///If true, the user can see the VR render inside his HMD
+	virtual bool isVisibleInHmd() = 0;
+
+	///Refresh and update the head tracking. May tell the VR client library to prepare for new frame
+	virtual void updateTracking() = 0;
+
+	///Render frame internally inside Ogre, and submit it to the VR client
+	virtual void renderAndSubmitFrame() = 0;
+
+	///Put the current position as the center of tracking
+	virtual void recenter() = 0;
+
+	///Change the color of the pixels when there is *nothing*
+	virtual void changeViewportBackgroundColor(Ogre::ColourValue) = 0;
+
+	///(Optional) Cycle through the client debug display if available.
+	virtual void cycleDebugHud() {};
+
+	///Set the VR cameras near clipping plane distance
+	virtual void setCamerasNearClippingDistance(float distance) = 0;
+	
+	///Set the VR cameras far clipping plane distance
+	virtual void setCameraFarClippingDistance(float distance) = 0;
+
+	///The current position of the head center defined by the client library projected in World Space
+	OgrePose returnPose;
+
+protected:
+	Ogre::SceneManager* smgr;
+	Ogre::Root* root;
+	Ogre::RenderWindow* window;
+	double updateTime;
+
+	Ogre::Real nearClippingDistance;
+	Ogre::Real farClippingDistance;
+
+	Ogre::Vector3 headPosition;
+	Ogre::Quaternion headOrientation;
+
+	std::string name;
+
+	Ogre::SceneNode* headNode;
+
+	static OgreVRRender* self;
+	///background color of viewports
+	Ogre::ColourValue backgroundColor;
+
+};

--- a/msvc/Annwvyn/Annwvyn-2015.vcxproj
+++ b/msvc/Annwvyn/Annwvyn-2015.vcxproj
@@ -222,6 +222,7 @@ COPY "$(TargetDir)\Annwvyn.pdb" "$(TargetDir)\..\template\"
     <ClInclude Include="..\..\include\euler.h" />
     <ClInclude Include="..\..\include\OculusInterface.hpp" />
     <ClInclude Include="..\..\include\OgreOculusRender.hpp" />
+    <ClInclude Include="..\..\include\OgreVRRender.hpp" />
     <ClInclude Include="..\..\include\systemMacro.h" />
     <ClInclude Include="..\..\include\tinyxml2.h" />
     <ClInclude Include="..\..\pch\stdafx.h" />
@@ -260,6 +261,7 @@ COPY "$(TargetDir)\Annwvyn.pdb" "$(TargetDir)\..\template\"
     <ClCompile Include="..\..\src\OculusInterface.cpp" />
     <ClCompile Include="..\..\src\OgreOculusRender.cpp" />
     <ClCompile Include="..\..\src\AnnLogger.cpp" />
+    <ClCompile Include="..\..\src\OgreVRRender.cpp" />
     <ClCompile Include="..\..\src\tinyxml2.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/msvc/Annwvyn/Annwvyn-2015.vcxproj.filters
+++ b/msvc/Annwvyn/Annwvyn-2015.vcxproj.filters
@@ -1,9 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Oculus rendering for Ogre">
-      <UniqueIdentifier>{80903f3b-ac93-417b-881a-c6fe14583547}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Annwvyn">
       <UniqueIdentifier>{71f4958c-4a0c-4d65-b5f2-9132994bfa62}</UniqueIdentifier>
     </Filter>
@@ -69,6 +66,12 @@
     </Filter>
     <Filter Include="Annwvyn\SubSystems\Scenery">
       <UniqueIdentifier>{5c9abb67-b981-4469-9dd8-f1658f374bb2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="OgreRenderingForVR">
+      <UniqueIdentifier>{80903f3b-ac93-417b-881a-c6fe14583547}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="OgreRenderingForVR\Oculus">
+      <UniqueIdentifier>{d83246f2-30b0-4dc4-96c9-644b2e03f8a3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -153,12 +156,6 @@
     <ClInclude Include="..\..\include\Annwvyn.h">
       <Filter>Annwvyn</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\OculusInterface.hpp">
-      <Filter>Oculus rendering for Ogre</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\include\OgreOculusRender.hpp">
-      <Filter>Oculus rendering for Ogre</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\AnnResourceManager.hpp">
       <Filter>Annwvyn\SubSystems\Resource</Filter>
     </ClInclude>
@@ -182,6 +179,15 @@
     </ClInclude>
     <ClInclude Include="..\..\include\AnnSceneryManager.hpp">
       <Filter>Annwvyn\SubSystems\Scenery</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\OculusInterface.hpp">
+      <Filter>OgreRenderingForVR\Oculus</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\OgreOculusRender.hpp">
+      <Filter>OgreRenderingForVR\Oculus</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\OgreVRRender.hpp">
+      <Filter>OgreRenderingForVR</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -248,12 +254,6 @@
     <ClCompile Include="..\..\src\AnnLightObject.cpp">
       <Filter>Annwvyn\GameObject\LightObject</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\OculusInterface.cpp">
-      <Filter>Oculus rendering for Ogre</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\OgreOculusRender.cpp">
-      <Filter>Oculus rendering for Ogre</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\AnnResourceManager.cpp">
       <Filter>Annwvyn\SubSystems\Resource</Filter>
     </ClCompile>
@@ -277,6 +277,15 @@
     </ClCompile>
     <ClCompile Include="..\..\src\AnnSceneryManager.cpp">
       <Filter>Annwvyn\SubSystems\Scenery</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\OculusInterface.cpp">
+      <Filter>OgreRenderingForVR\Oculus</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\OgreOculusRender.cpp">
+      <Filter>OgreRenderingForVR\Oculus</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\OgreVRRender.cpp">
+      <Filter>OgreRenderingForVR</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/msvc/Annwvyn/Main Class Diagram.cd
+++ b/msvc/Annwvyn/Main Class Diagram.cd
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
   <Class Name="Annwvyn::AnnAudioEngine">
-    <Position X="30.25" Y="3.5" Width="3.75" />
+    <Position X="31.25" Y="3.5" Width="3.75" />
     <TypeIdentifier>
-      <HashCode>IgAgAAgAIgIAIkIEAAgCAAgUACAgAAAAAAEgAAAMAIA=</HashCode>
+      <HashCode>IgAgAAgAIgIAIkIEAAgCAAgcACAgAAIAAAEgAAAMAIA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnAudioEngine.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnEventManager">
-    <Position X="10.5" Y="3.5" Width="4" />
+    <Position X="11.5" Y="3.5" Width="4" />
     <TypeIdentifier>
       <HashCode>ACkAAwAAEAAxIAAAQgAAADAAQJABTFAAAAAIaBAECAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -18,26 +18,25 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="OgreOculusRender">
-    <Position X="43.75" Y="8.75" Width="3.75" />
+    <Position X="8.75" Y="24.5" Width="3.75" />
     <NestedTypes>
-      <Enum Name="OgreOculusRender::__unnamed_enum_0022_1" Collapsed="true">
+      <Enum Name="OgreOculusRender::oorEyeType" Collapsed="true">
         <TypeIdentifier>
           <NewMemberFileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreOculusRender.hpp</NewMemberFileName>
         </TypeIdentifier>
       </Enum>
     </NestedTypes>
     <TypeIdentifier>
-      <HashCode>RIyCESWIPQdZAgGBBCAhRgoGKEAEAQiITwHABggBBAA=</HashCode>
+      <HashCode>BAyCkSUILIcZRkGQBSgBRgiGKEAAAgiAzwHABggABAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreOculusRender.hpp</FileName>
     </TypeIdentifier>
     <ShowAsAssociation>
       <Field Name="Oculus" />
-      <Field Name="backgroundColor" />
       <Field Name="returnPose" />
     </ShowAsAssociation>
   </Class>
   <Class Name="OculusInterface">
-    <Position X="49.5" Y="18" Width="2.25" />
+    <Position X="5.5" Y="27.25" Width="2.25" />
     <NestedTypes>
       <Enum Name="OculusInterface::__unnamed_enum_0021_1" Collapsed="true">
         <TypeIdentifier>
@@ -51,7 +50,7 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnEvent">
-    <Position X="24.25" Y="10.5" Width="2" />
+    <Position X="25.25" Y="10.5" Width="2" />
     <TypeIdentifier>
       <HashCode>AAAABIAAAAAAAAAAAAAAAAAAAQABAAAAEAAAAAgQAEQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -61,7 +60,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnKeyEvent">
-    <Position X="28.25" Y="14" Width="2" />
+    <Position X="29.25" Y="14" Width="2" />
     <TypeIdentifier>
       <HashCode>AAQAGAAAAAAAAAAABQAEAAAAAQAAAAAAAABACIAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -71,7 +70,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnMouseAxis">
-    <Position X="25.75" Y="6.75" Width="3.25" />
+    <Position X="26.75" Y="6.75" Width="3.25" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAACEEAAQAAIAAAAAAAAAQEAAAAAAAQAAAwA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -81,7 +80,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnMouseEvent">
-    <Position X="23" Y="14" Width="4.5" />
+    <Position X="24" Y="14" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAABBAAAEEAAAAAAAAAAAAAAABAAAAEAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -91,14 +90,14 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnStickEvent">
-    <Position X="31" Y="14" Width="3" />
+    <Position X="32" Y="14" Width="3" />
     <TypeIdentifier>
       <HashCode>AAQAAAAAAAAABAAAIAEgAAAAC0AAAABAAEAACKABAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnAbstractEventListener">
-    <Position X="33" Y="19.5" Width="2.75" />
+    <Position X="15" Y="26.5" Width="2.75" />
     <TypeIdentifier>
       <HashCode>AABgAAAAAAAAAAAAAIAAAABBEAAAAAABAAAAAAGAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -108,7 +107,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnDefaultEventListener">
-    <Position X="32" Y="22.75" Width="4.5" />
+    <Position X="14" Y="29.75" Width="4.5" />
     <NestedTypes>
       <Enum Name="Annwvyn::AnnDefaultEventListener::__unnamed_enum_0008_1" Collapsed="true">
         <TypeIdentifier>
@@ -130,7 +129,7 @@
     </ShowAsCollectionAssociation>
   </Class>
   <Class Name="Annwvyn::AnnGameObject">
-    <Position X="20" Y="17.5" Width="5" />
+    <Position X="21" Y="17.5" Width="5" />
     <TypeIdentifier>
       <HashCode>ECBkKEgAAAEQQQChABMBBQCSIRFMEFAHMRUBCBEADgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnGameObject.hpp</FileName>
@@ -140,7 +139,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnPlayer">
-    <Position X="33.25" Y="28.25" Width="4" />
+    <Position X="42.75" Y="21" Width="4" />
     <TypeIdentifier>
       <HashCode>AAIBoggFCAESIgSDgEEAAAgilAAACQgCEAGBQAQISCw=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayer.hpp</FileName>
@@ -150,7 +149,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::bodyParams">
-    <Position X="29.5" Y="36" Width="2.5" />
+    <Position X="42.5" Y="32.5" Width="2.5" />
     <TypeIdentifier>
       <HashCode>AIEEAAAAAQAQAAAoAAQBAAAAAAAAAAAAAAAABAAAAgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayer.hpp</FileName>
@@ -161,28 +160,28 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnCharacter">
-    <Position X="21" Y="30.5" Width="3.25" />
+    <Position X="22" Y="30.5" Width="3.25" />
     <TypeIdentifier>
       <HashCode>AAUAAAAgAIAAgBAAAAAAAAAAAACEAATAAAAAAgEAABA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnCharacter.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnPhysicsEngine">
-    <Position X="34.75" Y="3.5" Width="7.75" />
+    <Position X="35.75" Y="3.5" Width="7.75" />
     <TypeIdentifier>
       <HashCode>IAhAAgAAAAAABCEDABAAAABIAACgAAEISAEAQgAEAGA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPhysicsEngine.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTriggerObject">
-    <Position X="27.75" Y="27.5" Width="3.5" />
+    <Position X="37.75" Y="24.5" Width="3.5" />
     <TypeIdentifier>
       <HashCode>BgAgKAIAAAACAAAAAAAAIAACAAAAAAAACAAAAABAQAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnTriggerObject.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnStickAxis">
-    <Position X="39.75" Y="23.25" Width="3" />
+    <Position X="17.75" Y="35.25" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAEEAAQAAAAAAAQAAAAQAAgAAABASgAAgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -192,23 +191,23 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnVect3">
-    <Position X="27" Y="20.75" Width="3.75" />
+    <Position X="28" Y="20.75" Width="3.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAACAAAAAAAAAAAAAAAAAIAAAAAAAgCAAQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnVect3.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Ogre::Vector3" Collapsed="true">
-    <Position X="28.25" Y="19.5" Width="1.5" />
+    <Position X="29.25" Y="19.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAJAIFAAIIAAAAAAAEEAIUAAgEkAAGBAUQBgBQgEIQo=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OgreSDK\include\OGRE\OgreVector3.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnEngine">
-    <Position X="36.75" Y="10.75" Width="3.75" />
+    <Position X="40.75" Y="11.25" Width="3.75" />
     <TypeIdentifier>
-      <HashCode>QggADGACyEAyEQBgBgAKCBYAARgBBQFRRAAAEBQIgAU=</HashCode>
+      <HashCode>QgiABGACyEAyAQBgBgAKCBYAARgBBQFRRAAIEBQIkAU=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEngine.hpp</FileName>
     </TypeIdentifier>
     <ShowAsAssociation>
@@ -227,7 +226,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnLevelManager">
-    <Position X="61.75" Y="3.5" Width="3" />
+    <Position X="62.75" Y="3.5" Width="3" />
     <TypeIdentifier>
       <HashCode>AEACAAEAAAAAAAAAAAEgAAAAgAAAAAAAAAAwAAAEAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnLevelManager.hpp</FileName>
@@ -237,14 +236,14 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnConsole">
-    <Position X="15.25" Y="3.5" Width="9" />
+    <Position X="16.25" Y="3.5" Width="9" />
     <TypeIdentifier>
       <HashCode>AAKAAEiAAAAAEAAAAAAAAAICAAAAAgAAAAVQACBEJAE=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnConsole.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnPlayerActuator">
-    <Position X="8" Y="24.5" Width="2.25" />
+    <Position X="33" Y="24.5" Width="2.25" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEBAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayerActuator.hpp</FileName>
@@ -254,7 +253,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnSplashLevel">
-    <Position X="12.5" Y="21" Width="5.5" />
+    <Position X="13.5" Y="21" Width="5.5" />
     <TypeIdentifier>
       <HashCode>AICAEAAAJIAAgAAAAgAgAAAAQEQEBACAAAACAAIAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnSplashLevel.hpp</FileName>
@@ -264,42 +263,42 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnAbstractLevel">
-    <Position X="10.75" Y="16.5" Width="4.75" />
+    <Position X="11.75" Y="16.5" Width="4.75" />
     <TypeIdentifier>
       <HashCode>AIgAAAAAAMAAAAEAAAAAAQEIAEAEAAAAAAAAIgAAQAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnAbstractLevel.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnXmlLevel">
-    <Position X="8.25" Y="21" Width="3.5" />
+    <Position X="9.25" Y="21" Width="3.5" />
     <TypeIdentifier>
       <HashCode>AAAAAACAAIIAAAAAgQAAAAAAAEAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnXmlLevel.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTimeEvent">
-    <Position X="16.75" Y="14" Width="2.25" />
+    <Position X="17.75" Y="14" Width="2.25" />
     <TypeIdentifier>
       <HashCode>AAAIAAAAAAAAAACAAAAAAAAAAAAAAAAAAAQAIAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTriggerEvent">
-    <Position X="19.75" Y="14" Width="2.5" />
+    <Position X="20.75" Y="14" Width="2.5" />
     <TypeIdentifier>
       <HashCode>AAgAAAAAAAAAAAAAAAAAAAgAAAAAAKAAAAAAAAEAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnAlignedBoxTriggerObject">
-    <Position X="27" Y="32" Width="4.75" />
+    <Position X="37" Y="29" Width="4.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAgAACAAIAAAAgAAgAEAAEAAAAACBAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnTriggerObject.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnAudioSource">
-    <Position X="12.75" Y="11.75" Width="3.25" />
+    <Position X="13.75" Y="11.75" Width="3.25" />
     <TypeIdentifier>
       <HashCode>QAABAAAAAAAAAAIBAAAAEIAIBACgAAAAAAAAiAAAoAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnAudioEngine.hpp</FileName>
@@ -309,7 +308,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnDebug" Collapsed="true">
-    <Position X="65.75" Y="0.5" Width="1.5" />
+    <Position X="68.5" Y="0.5" Width="1.5" />
     <Compartments>
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
@@ -319,21 +318,21 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnDefaultPlayerActuator">
-    <Position X="8" Y="26.5" Width="2.25" />
+    <Position X="33" Y="26.5" Width="2.25" />
     <TypeIdentifier>
       <HashCode>AAAAAAAgAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayerActuator.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Ogre::Euler">
-    <Position X="22.5" Y="36.25" Width="5.25" />
+    <Position X="46.75" Y="32.75" Width="5.25" />
     <TypeIdentifier>
       <HashCode>ABAIAAEAiQCABAAgAARQAUAgKgAIENAAgAQgAAAAAEI=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\euler.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnLightObject">
-    <Position X="5.5" Y="11.25" Width="2.75" />
+    <Position X="6.5" Y="11.25" Width="2.75" />
     <Compartments>
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
@@ -353,7 +352,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnFilesystemManager">
-    <Position X="56.75" Y="3.5" Width="4.25" />
+    <Position X="57.75" Y="3.5" Width="4.25" />
     <TypeIdentifier>
       <HashCode>AgCIAAABQABAAAEEABKMAAAAAAAgAAAAAAAAAABIACI=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
@@ -364,35 +363,35 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Ogre::Light" Collapsed="true">
-    <Position X="9.25" Y="12.75" Width="1.5" />
+    <Position X="10" Y="12.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>EOJjMIgEAEwJEFSRCCgwBpBSAXhBgoe7g8bpAoAGA5g=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OgreSDK\include\OGRE\OgreLight.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnQuaternion">
-    <Position X="12" Y="27.75" Width="5.75" />
+    <Position X="28" Y="29.75" Width="5.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAQAAAAACAAAAAAAAAAAAAAEAAIAAAAAACAAAIQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnQuaternion.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Ogre::Quaternion" Collapsed="true">
-    <Position X="14.25" Y="26.5" Width="1.5" />
+    <Position X="30.25" Y="28.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAACEIMAEAqQAQEAAAJAAQAADAkAAGAIAQhgBQBSAQY=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OgreSDK\include\OGRE\OgreQuaternion.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnSubSystem">
-    <Position X="36.25" Y="0.5" Width="2.75" />
+    <Position X="37.25" Y="0.5" Width="2.75" />
     <TypeIdentifier>
       <HashCode>AAAABAAAAAAAAAAAAAAAAAAAAACEAAAAAAAAAAAEBAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnSubsystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::JoystickBuffer">
-    <Position X="42.25" Y="35" Width="3" />
+    <Position X="25.25" Y="43" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAACAQAAAAAAQAAAAAIAAAABQAAAAAgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -402,84 +401,91 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="OIS::JoyStick">
-    <Position X="41" Y="29.5" Width="5.25" />
+    <Position X="24" Y="37.5" Width="5.25" />
     <TypeIdentifier>
       <HashCode>QAEIAAAQGAAAAAAwAAAAQAAAAAAAAAAAASAAAgAAEAE=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OIS\include\OISJoyStick.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTextInputer">
-    <Position X="6" Y="5.5" Width="3" />
+    <Position X="7" Y="5.5" Width="3" />
     <TypeIdentifier>
       <HashCode>EBAAgAEAQAAAgAAAABAAAAAAAAAAABAQAEAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnResourceManager">
-    <Position X="25" Y="3.5" Width="4.5" />
+    <Position X="26" Y="3.5" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAACAAAEAAAAAAAAAAAAAACAAgAAAAAAAAACAgAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnResourceManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnGameObjectManager">
-    <Position X="43.25" Y="3.5" Width="5.75" />
+    <Position X="44.25" Y="3.5" Width="5.75" />
     <TypeIdentifier>
       <HashCode>ABAAAAAAQAAAAAAAAAAAAhQACEAAAAEEAACAQAgEAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnGameObjectManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnSceneryManager">
-    <Position X="49.75" Y="3.5" Width="6.25" />
+    <Position X="50.75" Y="3.5" Width="6.25" />
     <TypeIdentifier>
       <HashCode>AAgARAAAEBAAAAAAAAgAAAgEAAAAAAAAAAAAAAAAhIA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnSceneryManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Annwvyn::AnnColor">
-    <Position X="48.75" Y="8.75" Width="3.75" />
+  <Class Name="Annwvyn::AnnColor" Collapsed="true">
+    <Position X="66.75" Y="0.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>BAAAACAQRIABAAAAAAIAQAAAAAAABAAoAQABIAEAGIA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnColor.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnSaveDataInterpretor" Collapsed="true">
-    <Position X="67.5" Y="0.5" Width="1.5" />
+    <Position X="66.75" Y="1.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>wAAAEABAAAAAAQAAAEAIABAAAAAAAAAAAAAAAAAAAAQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTimer" Collapsed="true">
-    <Position X="65.75" Y="1.5" Width="1.5" />
+    <Position X="68.5" Y="1.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>IAAIAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnFileReader">
-    <Position X="57.5" Y="9.25" Width="3" />
+    <Position X="58.5" Y="9.25" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAEAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnFileWriter">
-    <Position X="57.5" Y="1.25" Width="3" />
+    <Position X="58.5" Y="1.25" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAQAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
+  <Class Name="OgreVRRender">
+    <Position X="35.75" Y="15.5" Width="3.75" />
+    <TypeIdentifier>
+      <HashCode>QIAAAQCAEIQYREERAQggAgqAAAAUAwgIyAAgAAgBAAA=</HashCode>
+      <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreVRRender.hpp</FileName>
+    </TypeIdentifier>
+  </Class>
   <Struct Name="OgrePose">
-    <Position X="48.75" Y="16" Width="2" />
+    <Position X="5.75" Y="31.25" Width="2" />
     <TypeIdentifier>
       <HashCode>AAABAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
-      <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreOculusRender.hpp</FileName>
+      <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreVRRender.hpp</FileName>
     </TypeIdentifier>
   </Struct>
   <Struct Name="Annwvyn::collisionTest">
-    <Position X="16.75" Y="19" Width="1.75" />
+    <Position X="27.75" Y="26" Width="1.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAgAAAAAAAAIAAEAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnGameObject.hpp</FileName>
@@ -490,49 +496,49 @@
     </ShowAsAssociation>
   </Struct>
   <Typedef Name="Annwvyn::StickAxisId" Collapsed="true">
-    <Position X="37.5" Y="24.5" Width="1.5" />
+    <Position X="19.5" Y="31.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Typedef>
   <Enum Name="Annwvyn::MouseAxisId">
-    <Position X="27.5" Y="11.5" Width="1.5" />
+    <Position X="28.5" Y="11.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAYAE=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::KeyCode::code" Collapsed="true">
-    <Position X="30.5" Y="12.25" Width="1.5" />
+    <Position X="31.5" Y="12.25" Width="1.5" />
     <TypeIdentifier>
       <HashCode>CokQoWkKQBD7kBeq8xUFgKAACQE4DC7+//9pX4QOogE=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnKeyCode.h</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::walkDirection" Collapsed="true">
-    <Position X="65.75" Y="3.5" Width="1.5" />
+    <Position X="66.75" Y="3.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAgAAAAAAgAAAAAAAAAAAAAAIAAAAAAAAAAAAgAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayer.hpp</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::phyShapeType" Collapsed="true">
-    <Position X="67.5" Y="2.75" Width="1.5" />
+    <Position X="68.5" Y="2.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAQIAAAAAAACEAAAAAAAgAAAEAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnTypes.h</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::MouseButtonId" Collapsed="true">
-    <Position X="65.75" Y="2.75" Width="1.5" />
+    <Position X="66.75" Y="2.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAQAAAAAAAAAAAAAwCMAAAAAAAAACAGQAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::AnnEventType">
-    <Position X="21.5" Y="11.25" Width="1.75" />
+    <Position X="22.5" Y="11.25" Width="1.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAoAAAAAAAAAABAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>

--- a/msvc/Annwvyn/Main Class Diagram.cd
+++ b/msvc/Annwvyn/Main Class Diagram.cd
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ClassDiagram MajorVersion="1" MinorVersion="1" MembersFormat="FullSignature">
   <Class Name="Annwvyn::AnnAudioEngine">
-    <Position X="31.25" Y="3.5" Width="3.75" />
+    <Position X="26.25" Y="3.5" Width="3.75" />
     <TypeIdentifier>
       <HashCode>IgAgAAgAIgIAIkIEAAgCAAgcACAgAAIAAAEgAAAMAIA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnAudioEngine.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnEventManager">
-    <Position X="11.5" Y="3.5" Width="4" />
+    <Position X="6.5" Y="3.5" Width="4" />
     <TypeIdentifier>
       <HashCode>ACkAAwAAEAAxIAAAQgAAADAAQJABTFAAAAAIaBAECAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -18,7 +18,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="OgreOculusRender">
-    <Position X="8.75" Y="24.5" Width="3.75" />
+    <Position X="3.75" Y="24.5" Width="4" />
     <NestedTypes>
       <Enum Name="OgreOculusRender::oorEyeType" Collapsed="true">
         <TypeIdentifier>
@@ -32,11 +32,10 @@
     </TypeIdentifier>
     <ShowAsAssociation>
       <Field Name="Oculus" />
-      <Field Name="returnPose" />
     </ShowAsAssociation>
   </Class>
   <Class Name="OculusInterface">
-    <Position X="5.5" Y="27.25" Width="2.25" />
+    <Position X="0.5" Y="27.25" Width="2.25" />
     <NestedTypes>
       <Enum Name="OculusInterface::__unnamed_enum_0021_1" Collapsed="true">
         <TypeIdentifier>
@@ -50,7 +49,7 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnEvent">
-    <Position X="25.25" Y="10.5" Width="2" />
+    <Position X="20.25" Y="10.5" Width="2" />
     <TypeIdentifier>
       <HashCode>AAAABIAAAAAAAAAAAAAAAAAAAQABAAAAEAAAAAgQAEQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -60,7 +59,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnKeyEvent">
-    <Position X="29.25" Y="14" Width="2" />
+    <Position X="24.25" Y="14" Width="2" />
     <TypeIdentifier>
       <HashCode>AAQAGAAAAAAAAAAABQAEAAAAAQAAAAAAAABACIAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -70,7 +69,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnMouseAxis">
-    <Position X="26.75" Y="6.75" Width="3.25" />
+    <Position X="21.5" Y="6.75" Width="3.25" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAACEEAAQAAIAAAAAAAAAQEAAAAAAAQAAAwA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -80,7 +79,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnMouseEvent">
-    <Position X="24" Y="14" Width="4.5" />
+    <Position X="19" Y="14" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAABBAAAEEAAAAAAAAAAAAAAABAAAAEAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -90,14 +89,14 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnStickEvent">
-    <Position X="32" Y="14" Width="3" />
+    <Position X="27" Y="14" Width="3" />
     <TypeIdentifier>
       <HashCode>AAQAAAAAAAAABAAAIAEgAAAAC0AAAABAAEAACKABAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnAbstractEventListener">
-    <Position X="15" Y="26.5" Width="2.75" />
+    <Position X="10" Y="26.5" Width="2.75" />
     <TypeIdentifier>
       <HashCode>AABgAAAAAAAAAAAAAIAAAABBEAAAAAABAAAAAAGAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -107,7 +106,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnDefaultEventListener">
-    <Position X="14" Y="29.75" Width="4.5" />
+    <Position X="9" Y="29.75" Width="4.5" />
     <NestedTypes>
       <Enum Name="Annwvyn::AnnDefaultEventListener::__unnamed_enum_0008_1" Collapsed="true">
         <TypeIdentifier>
@@ -129,7 +128,7 @@
     </ShowAsCollectionAssociation>
   </Class>
   <Class Name="Annwvyn::AnnGameObject">
-    <Position X="21" Y="17.5" Width="5" />
+    <Position X="16" Y="17.5" Width="5" />
     <TypeIdentifier>
       <HashCode>ECBkKEgAAAEQQQChABMBBQCSIRFMEFAHMRUBCBEADgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnGameObject.hpp</FileName>
@@ -139,7 +138,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnPlayer">
-    <Position X="42.75" Y="21" Width="4" />
+    <Position X="37.75" Y="21" Width="4" />
     <TypeIdentifier>
       <HashCode>AAIBoggFCAESIgSDgEEAAAgilAAACQgCEAGBQAQISCw=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayer.hpp</FileName>
@@ -149,7 +148,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::bodyParams">
-    <Position X="42.5" Y="32.5" Width="2.5" />
+    <Position X="27.5" Y="20.5" Width="2.5" />
     <TypeIdentifier>
       <HashCode>AIEEAAAAAQAQAAAoAAQBAAAAAAAAAAAAAAAABAAAAgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayer.hpp</FileName>
@@ -160,28 +159,28 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnCharacter">
-    <Position X="22" Y="30.5" Width="3.25" />
+    <Position X="17" Y="30.5" Width="3.25" />
     <TypeIdentifier>
       <HashCode>AAUAAAAgAIAAgBAAAAAAAAAAAACEAATAAAAAAgEAABA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnCharacter.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnPhysicsEngine">
-    <Position X="35.75" Y="3.5" Width="7.75" />
+    <Position X="30.75" Y="3.5" Width="7.75" />
     <TypeIdentifier>
       <HashCode>IAhAAgAAAAAABCEDABAAAABIAACgAAEISAEAQgAEAGA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPhysicsEngine.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTriggerObject">
-    <Position X="37.75" Y="24.5" Width="3.5" />
+    <Position X="32.75" Y="24.5" Width="3.5" />
     <TypeIdentifier>
       <HashCode>BgAgKAIAAAACAAAAAAAAIAACAAAAAAAACAAAAABAQAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnTriggerObject.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnStickAxis">
-    <Position X="17.75" Y="35.25" Width="3" />
+    <Position X="12.75" Y="35.25" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAEEAAQAAAAAAAQAAAAQAAgAAABASgAAgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -191,21 +190,21 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnVect3">
-    <Position X="28" Y="20.75" Width="3.75" />
+    <Position X="23" Y="20.75" Width="3.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAACAAAAAAAAAAAAAAAAAIAAAAAAAgCAAQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnVect3.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Ogre::Vector3" Collapsed="true">
-    <Position X="29.25" Y="19.5" Width="1.5" />
+    <Position X="24.25" Y="19.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAJAIFAAIIAAAAAAAEEAIUAAgEkAAGBAUQBgBQgEIQo=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OgreSDK\include\OGRE\OgreVector3.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnEngine">
-    <Position X="40.75" Y="11.25" Width="3.75" />
+    <Position X="35.75" Y="11.25" Width="3.75" />
     <TypeIdentifier>
       <HashCode>QgiABGACyEAyAQBgBgAKCBYAARgBBQFRRAAIEBQIkAU=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEngine.hpp</FileName>
@@ -226,7 +225,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnLevelManager">
-    <Position X="62.75" Y="3.5" Width="3" />
+    <Position X="57.75" Y="3.5" Width="3" />
     <TypeIdentifier>
       <HashCode>AEACAAEAAAAAAAAAAAEgAAAAgAAAAAAAAAAwAAAEAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnLevelManager.hpp</FileName>
@@ -236,14 +235,14 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnConsole">
-    <Position X="16.25" Y="3.5" Width="9" />
+    <Position X="11.25" Y="3.5" Width="9" />
     <TypeIdentifier>
       <HashCode>AAKAAEiAAAAAEAAAAAAAAAICAAAAAgAAAAVQACBEJAE=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnConsole.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnPlayerActuator">
-    <Position X="33" Y="24.5" Width="2.25" />
+    <Position X="28" Y="24.5" Width="2.25" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEBAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayerActuator.hpp</FileName>
@@ -253,7 +252,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnSplashLevel">
-    <Position X="13.5" Y="21" Width="5.5" />
+    <Position X="8.5" Y="21" Width="5.5" />
     <TypeIdentifier>
       <HashCode>AICAEAAAJIAAgAAAAgAgAAAAQEQEBACAAAACAAIAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnSplashLevel.hpp</FileName>
@@ -263,42 +262,42 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnAbstractLevel">
-    <Position X="11.75" Y="16.5" Width="4.75" />
+    <Position X="6.75" Y="16.5" Width="4.75" />
     <TypeIdentifier>
       <HashCode>AIgAAAAAAMAAAAEAAAAAAQEIAEAEAAAAAAAAIgAAQAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnAbstractLevel.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnXmlLevel">
-    <Position X="9.25" Y="21" Width="3.5" />
+    <Position X="4.25" Y="21" Width="3.5" />
     <TypeIdentifier>
       <HashCode>AAAAAACAAIIAAAAAgQAAAAAAAEAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnXmlLevel.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTimeEvent">
-    <Position X="17.75" Y="14" Width="2.25" />
+    <Position X="12.75" Y="14" Width="2.25" />
     <TypeIdentifier>
       <HashCode>AAAIAAAAAAAAAACAAAAAAAAAAAAAAAAAAAQAIAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTriggerEvent">
-    <Position X="20.75" Y="14" Width="2.5" />
+    <Position X="15.75" Y="14" Width="2.5" />
     <TypeIdentifier>
       <HashCode>AAgAAAAAAAAAAAAAAAAAAAgAAAAAAKAAAAAAAAEAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnAlignedBoxTriggerObject">
-    <Position X="37" Y="29" Width="4.75" />
+    <Position X="32" Y="29" Width="4.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAgAACAAIAAAAgAAgAEAAEAAAAACBAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnTriggerObject.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnAudioSource">
-    <Position X="13.75" Y="11.75" Width="3.25" />
+    <Position X="8.75" Y="11.75" Width="3.25" />
     <TypeIdentifier>
       <HashCode>QAABAAAAAAAAAAIBAAAAEIAIBACgAAAAAAAAiAAAoAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnAudioEngine.hpp</FileName>
@@ -308,7 +307,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnDebug" Collapsed="true">
-    <Position X="68.5" Y="0.5" Width="1.5" />
+    <Position X="63.5" Y="0.5" Width="1.5" />
     <Compartments>
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
@@ -318,21 +317,21 @@
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnDefaultPlayerActuator">
-    <Position X="33" Y="26.5" Width="2.25" />
+    <Position X="28" Y="26.5" Width="2.25" />
     <TypeIdentifier>
       <HashCode>AAAAAAAgAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayerActuator.hpp</FileName>
     </TypeIdentifier>
   </Class>
-  <Class Name="Ogre::Euler">
-    <Position X="46.75" Y="32.75" Width="5.25" />
+  <Class Name="Ogre::Euler" Collapsed="true">
+    <Position X="24.5" Y="18" Width="1.5" />
     <TypeIdentifier>
       <HashCode>ABAIAAEAiQCABAAgAARQAUAgKgAIENAAgAQgAAAAAEI=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\euler.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnLightObject">
-    <Position X="6.5" Y="11.25" Width="2.75" />
+    <Position X="1.25" Y="11.25" Width="2.75" />
     <Compartments>
       <Compartment Name="Nested Types" Collapsed="false" />
     </Compartments>
@@ -352,7 +351,7 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Annwvyn::AnnFilesystemManager">
-    <Position X="57.75" Y="3.5" Width="4.25" />
+    <Position X="52.75" Y="3.5" Width="4.25" />
     <TypeIdentifier>
       <HashCode>AgCIAAABQABAAAEEABKMAAAAAAAgAAAAAAAAAABIACI=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
@@ -363,35 +362,35 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="Ogre::Light" Collapsed="true">
-    <Position X="10" Y="12.75" Width="1.5" />
+    <Position X="5" Y="12.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>EOJjMIgEAEwJEFSRCCgwBpBSAXhBgoe7g8bpAoAGA5g=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OgreSDK\include\OGRE\OgreLight.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnQuaternion">
-    <Position X="28" Y="29.75" Width="5.75" />
+    <Position X="23" Y="29.75" Width="5.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAQAAAAACAAAAAAAAAAAAAAEAAIAAAAAACAAAIQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnQuaternion.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Ogre::Quaternion" Collapsed="true">
-    <Position X="30.25" Y="28.5" Width="1.5" />
+    <Position X="25.25" Y="28.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAACEIMAEAqQAQEAAAJAAQAADAkAAGAIAQhgBQBSAQY=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OgreSDK\include\OGRE\OgreQuaternion.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnSubSystem">
-    <Position X="37.25" Y="0.5" Width="2.75" />
+    <Position X="32.25" Y="0.5" Width="2.75" />
     <TypeIdentifier>
       <HashCode>AAAABAAAAAAAAAAAAAAAAAAAAACEAAAAAAAAAAAEBAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnSubsystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::JoystickBuffer">
-    <Position X="25.25" Y="43" Width="3" />
+    <Position X="33" Y="41" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAACAQAAAAAAQAAAAAIAAAABQAAAAAgA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
@@ -401,91 +400,91 @@
     </ShowAsAssociation>
   </Class>
   <Class Name="OIS::JoyStick">
-    <Position X="24" Y="37.5" Width="5.25" />
+    <Position X="32" Y="35.5" Width="5.25" />
     <TypeIdentifier>
       <HashCode>QAEIAAAQGAAAAAAwAAAAQAAAAAAAAAAAASAAAgAAEAE=</HashCode>
       <FileName>c:\Oculus\AnnwvynSDK64_2015\OIS\include\OISJoyStick.h</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTextInputer">
-    <Position X="7" Y="5.5" Width="3" />
+    <Position X="2" Y="5.5" Width="3" />
     <TypeIdentifier>
       <HashCode>EBAAgAEAQAAAgAAAABAAAAAAAAAAABAQAEAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnResourceManager">
-    <Position X="26" Y="3.5" Width="4.5" />
+    <Position X="21" Y="3.5" Width="4.5" />
     <TypeIdentifier>
       <HashCode>AAAAACAAAEAAAAAAAAAAAAAACAAgAAAAAAAAACAgAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnResourceManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnGameObjectManager">
-    <Position X="44.25" Y="3.5" Width="5.75" />
+    <Position X="39.25" Y="3.5" Width="5.75" />
     <TypeIdentifier>
       <HashCode>ABAAAAAAQAAAAAAAAAAAAhQACEAAAAEEAACAQAgEAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnGameObjectManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnSceneryManager">
-    <Position X="50.75" Y="3.5" Width="6.25" />
+    <Position X="45.75" Y="3.5" Width="6.25" />
     <TypeIdentifier>
       <HashCode>AAgARAAAEBAAAAAAAAgAAAgEAAAAAAAAAAAAAAAAhIA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnSceneryManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnColor" Collapsed="true">
-    <Position X="66.75" Y="0.5" Width="1.5" />
+    <Position X="61.75" Y="0.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>BAAAACAQRIABAAAAAAIAQAAAAAAABAAoAQABIAEAGIA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnColor.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnSaveDataInterpretor" Collapsed="true">
-    <Position X="66.75" Y="1.5" Width="1.5" />
+    <Position X="61.75" Y="1.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>wAAAEABAAAAAAQAAAEAIABAAAAAAAAAAAAAAAAAAAAQ=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnTimer" Collapsed="true">
-    <Position X="68.5" Y="1.5" Width="1.5" />
+    <Position X="63.5" Y="1.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>IAAIAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnFileReader">
-    <Position X="58.5" Y="9.25" Width="3" />
+    <Position X="53.25" Y="9.25" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAEAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="Annwvyn::AnnFileWriter">
-    <Position X="58.5" Y="1.25" Width="3" />
+    <Position X="53.25" Y="1.25" Width="3" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAQAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnFilesystem.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Class Name="OgreVRRender">
-    <Position X="35.75" Y="15.5" Width="3.75" />
+    <Position X="31" Y="15.5" Width="3.75" />
     <TypeIdentifier>
-      <HashCode>QIAAAQCAEIQYREERAQggAgqAAAAUAwgIyAAgAAgBAAA=</HashCode>
+      <HashCode>QIAAAQCAEIQYREERAQggAgqAAAAUAwgIyQAgAAgBAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreVRRender.hpp</FileName>
     </TypeIdentifier>
   </Class>
   <Struct Name="OgrePose">
-    <Position X="5.75" Y="31.25" Width="2" />
+    <Position X="0.75" Y="31.25" Width="2" />
     <TypeIdentifier>
       <HashCode>AAABAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreVRRender.hpp</FileName>
     </TypeIdentifier>
   </Struct>
   <Struct Name="Annwvyn::collisionTest">
-    <Position X="27.75" Y="26" Width="1.75" />
+    <Position X="22.5" Y="26" Width="1.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAgAAAAAAAAIAAEAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnGameObject.hpp</FileName>
@@ -496,49 +495,49 @@
     </ShowAsAssociation>
   </Struct>
   <Typedef Name="Annwvyn::StickAxisId" Collapsed="true">
-    <Position X="19.5" Y="31.5" Width="1.5" />
+    <Position X="14.5" Y="31.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Typedef>
   <Enum Name="Annwvyn::MouseAxisId">
-    <Position X="28.5" Y="11.5" Width="1.5" />
+    <Position X="23.5" Y="11.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAYAE=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::KeyCode::code" Collapsed="true">
-    <Position X="31.5" Y="12.25" Width="1.5" />
+    <Position X="26.5" Y="12.25" Width="1.5" />
     <TypeIdentifier>
       <HashCode>CokQoWkKQBD7kBeq8xUFgKAACQE4DC7+//9pX4QOogE=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnKeyCode.h</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::walkDirection" Collapsed="true">
-    <Position X="66.75" Y="3.5" Width="1.5" />
+    <Position X="61.75" Y="3.5" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAgAAAAAAgAAAAAAAAAAAAAAIAAAAAAAAAAAAgAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnPlayer.hpp</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::phyShapeType" Collapsed="true">
-    <Position X="68.5" Y="2.75" Width="1.5" />
+    <Position X="63.5" Y="2.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAQIAAAAAAACEAAAAAAAgAAAEAAAAAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnTypes.h</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::MouseButtonId" Collapsed="true">
-    <Position X="66.75" Y="2.75" Width="1.5" />
+    <Position X="61.75" Y="2.75" Width="1.5" />
     <TypeIdentifier>
       <HashCode>AAAAAAQAAAAAAAAAAAAAwCMAAAAAAAAACAGQAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>
     </TypeIdentifier>
   </Enum>
   <Enum Name="Annwvyn::AnnEventType">
-    <Position X="22.5" Y="11.25" Width="1.75" />
+    <Position X="17.25" Y="11.25" Width="1.75" />
     <TypeIdentifier>
       <HashCode>AAAAAAAAAAAAAAAAAAoAAAAAAAAAABAAAAAAAAAAAAA=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\AnnEventManager.hpp</FileName>

--- a/msvc/Annwvyn/Main Class Diagram.cd
+++ b/msvc/Annwvyn/Main Class Diagram.cd
@@ -20,7 +20,7 @@
   <Class Name="OgreOculusRender">
     <Position X="43.75" Y="8.75" Width="3.75" />
     <NestedTypes>
-      <Enum Name="OgreOculusRender::__unnamed_enum_0021_1" Collapsed="true">
+      <Enum Name="OgreOculusRender::__unnamed_enum_0022_1" Collapsed="true">
         <TypeIdentifier>
           <NewMemberFileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OgreOculusRender.hpp</NewMemberFileName>
         </TypeIdentifier>
@@ -38,8 +38,15 @@
   </Class>
   <Class Name="OculusInterface">
     <Position X="49.5" Y="18" Width="2.25" />
+    <NestedTypes>
+      <Enum Name="OculusInterface::__unnamed_enum_0021_1" Collapsed="true">
+        <TypeIdentifier>
+          <NewMemberFileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OculusInterface.hpp</NewMemberFileName>
+        </TypeIdentifier>
+      </Enum>
+    </NestedTypes>
     <TypeIdentifier>
-      <HashCode>AAAAAAAAABAAAAAACAGAAAABIIAAACAAAAAAAAAAAAI=</HashCode>
+      <HashCode>AAAAAAAQAAAAAAAACAGAAAABIIAAACAAAAAAAAAAAAI=</HashCode>
       <FileName>C:\Oculus\AnnwvynSDK64_2015\Annwvyn\include\OculusInterface.hpp</FileName>
     </TypeIdentifier>
   </Class>

--- a/src/AnnAudioEngine.cpp
+++ b/src/AnnAudioEngine.cpp
@@ -248,7 +248,7 @@ void AnnAudioEngine::updateListenerOrient(AnnQuaternion orient)
 
 void AnnAudioEngine::update()
 {
-	OgrePose pose = AnnGetEngine()->getPoseFromOOR();
+	OgrePose pose = AnnGetEngine()->getHmdPose();
 	updateListenerPos(pose.position);
 	updateListenerOrient(pose.orientation);
 }

--- a/src/AnnAudioEngine.cpp
+++ b/src/AnnAudioEngine.cpp
@@ -53,7 +53,8 @@ void AnnAudioEngine::detectPlaybackDevices(const char *list)
 
 bool AnnAudioEngine::initOpenAL()
 {
-	if (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") == AL_TRUE)
+	if (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") == AL_TRUE
+		&& AnnGetVRRenderer()->usesCustomAudioDevice())
 	{
 		AnnDebug() << "Enumerating audio devices : ";
 		detectPlaybackDevices(alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER));
@@ -61,7 +62,8 @@ bool AnnAudioEngine::initOpenAL()
 		for (std::string deviceName : detectedDevices)
 		{
 			AnnDebug() << "Checking device : " << deviceName << " as Rift Audio";
-			if (deviceName.find("Rift Audio") != std::string::npos)
+			if (deviceName.
+				find(AnnGetVRRenderer()->getAudioDeviceIdentifierSubString()) != std::string::npos)
 			{
 				AnnDebug() << "Found Oculus Rift Audio Device!";
 				Device = alcOpenDevice(deviceName.c_str());
@@ -78,7 +80,7 @@ bool AnnAudioEngine::initOpenAL()
 	}
 	else
 	{
-		AnnDebug() << "The current OpenAL runtime doesn't support Device Enumeration, using the default device";
+		AnnDebug() << "Device enumeration unsuported, or VR headset don't need custom audio, using the default device";
 		Device = alcOpenDevice(NULL);
 	}
     if (!Device)

--- a/src/AnnDefaultEventListener.cpp
+++ b/src/AnnDefaultEventListener.cpp
@@ -18,8 +18,8 @@ AnnDefaultEventListener::AnnDefaultEventListener() : AnnAbstractEventListener(),
 	axes[ax_straff] = 1;
 	//Use second analog stick for horizontal rotation
 	axes[ax_rotate] = 3;
-	//Trim before 1/12 of the stick
-	deadzone = 1.0f/12.0f;
+	//Trim before 1/11 of the stick
+	deadzone = 1.0f/11.0f;
 
 	buttons[b_run] = 2;
 	buttons[b_jump] = 0;

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -42,19 +42,14 @@ AnnEngine::AnnEngine(const char title[]) :
 	//Launching initialisation routines : 
 	//All Ogre related critical component is done inside the OgreOculusRenderer class. 
 	renderer = new OgreOculusRender(title);
-	renderer->initLibraries("Annwvyn.log");
+	renderer->initOgreRoot("Annwvyn.log");
+
 	player = new AnnPlayer;
-	renderer->getOgreConfig();
-	renderer->createWindow();
-	renderer->initScene();
-	renderer->initCameras();
-	renderer->setCamerasNearClippingDistance(0.15f);
-	renderer->initRttRendering();
+	renderer->initVrHmd();
+	renderer->initPipeline();
 	SceneManager = renderer->getSceneManager();
 
-	log("OGRE Object-oriented Graphical Rendering Engine initialized", true);
-
-	renderer->showMonscopicView();
+	//renderer->showMonscopicView();
 
 	log("Setup Annwvyn's subsystems");
 	SubSystemList.push_back(levelManager = new AnnLevelManager);
@@ -167,10 +162,10 @@ void AnnEngine::initPlayerPhysics()
 	physicsEngine->initPlayerPhysics(player, povNode);
 }
 
-void AnnEngine::oculusInit()
+void AnnEngine::VrInit()
 {
-	log("Init Oculus rendering system");
-	renderer->initOculus();
+	log("Init VR rendering system");
+	renderer->initClientHmdRendering();
 	povNode = renderer->getCameraInformationNode();
 	povNode->setPosition(player->getPosition() +
 		AnnVect3(0.0f, player->getEyesHeight(), 0.0f));
@@ -183,7 +178,7 @@ bool AnnEngine::requestStop()
 	if (isKeyDown(OIS::KC_ESCAPE))
 		return true;
 	//If the user quit the App from the Oculus Home
-	if (renderer->getSessionStatus().ShouldQuit)
+	if (renderer->shouldQuit())
 		return true;
 	return false;
 }
@@ -265,7 +260,7 @@ double AnnEngine::getFrameTime()
 	return updateTime;
 }
 
-OgrePose AnnEngine::getPoseFromOOR()
+OgrePose AnnEngine::getHmdPose()
 {
 	if (renderer)
 		return renderer->returnPose;
@@ -285,8 +280,7 @@ void AnnEngine::openConsole()
 		freopen("CONOUT$", "w", stdout);
 #pragma warning(default:4996)
 
-		SetConsoleTitle(L"Annwyn Debug Console");
-		SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY);
+		
 	}
 	//Redirect cerr to cout
 	std::cerr.rdbuf(std::cout.rdbuf());
@@ -318,6 +312,10 @@ void AnnEngine::openConsole()
 
 	std::ios::sync_with_stdio();
 #endif
+
+	SetConsoleTitle(L"Annwyn Debug Console");
+	SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY);
+
 #endif
 }
 
@@ -328,12 +326,12 @@ void AnnEngine::toogleOnScreenConsole()
 
 void AnnEngine::toogleOculusPerfHUD()
 {
-	if (renderer) renderer->cycleOculusHUD();
+	if (renderer) renderer->cycleDebugHud();
 }
 
 bool AnnEngine::appVisibleInHMD()
 {
-	if (renderer->getSessionStatus().IsVisible == ovrTrue)
+	if (renderer->isVisibleInHmd() == true)
 		return true;
 	return false;
 }

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -119,6 +119,11 @@ AnnSceneryManager * Annwvyn::AnnEngine::getSceneryManager()
 	return sceneryManager;
 }
 
+OgreVRRender * Annwvyn::AnnEngine::getVRRenderer()
+{
+	return renderer;
+}
+
 AnnLevelManager* AnnEngine::getLevelManager()
 {
 	if (!canAccessSubSystems) return nullptr;

--- a/src/AnnEvents.cpp
+++ b/src/AnnEvents.cpp
@@ -160,6 +160,11 @@ AnnStickAxis::AnnStickAxis()
     setAbsValue(0);
 }
 
+StickAxisId AnnStickAxis::getAxisId()
+{
+	return id;
+}
+
 AnnStickAxis::AnnStickAxis(StickAxisId ax, int rel, int abs)
 {
     setAxis(ax);

--- a/src/AnnGameObjectManager.cpp
+++ b/src/AnnGameObjectManager.cpp
@@ -168,10 +168,10 @@ void Annwvyn::AnnGameObjectManager::destroyTriggerObject(AnnTriggerObject * trig
 AnnGameObject * Annwvyn::AnnGameObjectManager::playerLookingAt()
 {
 	//Origin vector of the ray
-	AnnVect3 Orig(AnnGetEngine()->getPoseFromOOR().position);
+	AnnVect3 Orig(AnnGetEngine()->getHmdPose().position);
 
 	//Caltulate direction Vector of the ray to be the midpont camera optical axis
-	AnnVect3 LookAt(AnnQuaternion(AnnGetEngine()->getPoseFromOOR().orientation).getAtVector());
+	AnnVect3 LookAt(AnnQuaternion(AnnGetEngine()->getHmdPose().orientation).getAtVector());
 
 	//create ray
 	Ogre::Ray ray(Orig, LookAt);

--- a/src/AnnSceneryManager.cpp
+++ b/src/AnnSceneryManager.cpp
@@ -4,7 +4,7 @@
 
 using namespace Annwvyn;
 
-AnnSceneryManager::AnnSceneryManager(OgreOculusRender* rendererFromEngine) : AnnSubSystem("SceneryManager"),
+AnnSceneryManager::AnnSceneryManager(OgreVRRender* rendererFromEngine) : AnnSubSystem("SceneryManager"),
 smgr(AnnGetEngine()->getSceneManager()),
 renderer(rendererFromEngine)
 {

--- a/src/OgreOculusRender.cpp
+++ b/src/OgreOculusRender.cpp
@@ -19,14 +19,10 @@ OgreOculusRender::OgreOculusRender(std::string winName) : OgreVRRender(winName),
 	textureSwapChain(0),
 	perfHudMode(ovrPerfHud_Off)
 {
-	
-	eyeCameras[left ] = nullptr;
-	eyeCameras[right] = nullptr;
 	vpts[left ] = nullptr;		
 	vpts[right] = nullptr;
 	monoCam = nullptr;
 	OculusSelf = static_cast<OgreOculusRender*>(self);
-
 }
 
 OgreOculusRender::~OgreOculusRender()

--- a/src/OgreOculusRender.cpp
+++ b/src/OgreOculusRender.cpp
@@ -7,38 +7,26 @@ using namespace Annwvyn;
 
 //Static class members
 bool OgreOculusRender::mirrorHMDView(true);
-OgreOculusRender* OgreOculusRender::self(nullptr);
 Ogre::TextureUnitState* OgreOculusRender::debugTexturePlane(nullptr);
-
-OgreOculusRender::OgreOculusRender(std::string winName) :
-	name(winName),
-	root(nullptr),
-	smgr(nullptr),
+OgreOculusRender* OgreOculusRender::OculusSelf = nullptr;
+OgreOculusRender::OgreOculusRender(std::string winName) : OgreVRRender(winName),
 	debugSmgr(nullptr),
 	Oculus(nullptr),
-	headPosition(0,0,10),
-	headOrientation(Ogre::Quaternion::IDENTITY),
 	nearClippingDistance(0.5f),
 	farClippingDistance(4000.0f),
 	lastOculusPosition(headPosition),
 	lastOculusOrientation(headOrientation),
-	updateTime(0),
-	backgroundColor(0,0.56f,1),
 	textureSwapChain(0),
 	perfHudMode(ovrPerfHud_Off)
 {
-	//Handle singleton thing.
-	if(self)
-	{
-		MessageBox(NULL, L"Fatal error with renderer initialisation. OgreOculusRender object allready created.", L"Fatal Error", MB_ICONERROR);
-		exit(ANN_ERR_RENDER);
-	}
-	self=this;
+	
 	eyeCameras[left ] = nullptr;
 	eyeCameras[right] = nullptr;
 	vpts[left ] = nullptr;		
 	vpts[right] = nullptr;
 	monoCam = nullptr;
+	OculusSelf = static_cast<OgreOculusRender*>(self);
+
 }
 
 OgreOculusRender::~OgreOculusRender()
@@ -57,9 +45,32 @@ OgreOculusRender::~OgreOculusRender()
 
 	root->unloadPlugin("Plugin_OctreeSceneManager");
 	delete root;
+
+
 }
 
-void OgreOculusRender::cycleOculusHUD()
+bool OgreOculusRender::shouldQuit()
+{
+	if (getSessionStatus().ShouldQuit == ovrTrue)
+		return true;
+	return false;
+}
+
+bool OgreOculusRender::shouldRecenter()
+{
+	if (getSessionStatus().ShouldRecenter == ovrTrue)
+		return true;
+	return false;
+}
+
+bool OgreOculusRender::isVisibleInHmd()
+{
+	if (getSessionStatus().IsVisible == ovrTrue)
+		return true;
+	return false;
+}
+
+void OgreOculusRender::cycleDebugHud()
 {
 	//Loop through the perf HUD mode available
 	perfHudMode = (perfHudMode+1) % (ovrPerfHud_Count);
@@ -68,32 +79,19 @@ void OgreOculusRender::cycleOculusHUD()
 	ovr_SetInt(Oculus->getSession(), "PerfHudMode", perfHudMode);
 }
 
-void OgreOculusRender::changeViewportBackgroundColor(Annwvyn::AnnColor color)
+void OgreOculusRender::changeViewportBackgroundColor(Ogre::ColourValue color)
 {
 	//save the color then apply it to each viewport
-	backgroundColor.setRed(color.getRed());
-	backgroundColor.setGreen(color.getGreen());
-	backgroundColor.setBlue(color.getBlue());
-	backgroundColor.setAlpha(color.getAlpha());
+	backgroundColor = (color);
 
 	//Render buffers
 	for(byte i(0); i < 2; i++)
 		if(vpts[i])
-			vpts[i]->setBackgroundColour(color.getOgreColor());
+			vpts[i]->setBackgroundColour(backgroundColor);
 
 	//Debug window
 	if(debugViewport && !mirrorHMDView)
-		debugViewport->setBackgroundColour(color.getOgreColor());
-}
-
-Ogre::SceneManager* OgreOculusRender::getSceneManager()
-{
-	return smgr;
-}
-
-Ogre::RenderWindow* OgreOculusRender::getWindow()
-{
-	return window;
+		debugViewport->setBackgroundColour(backgroundColor);
 }
 
 void OgreOculusRender::debugPrint()
@@ -113,10 +111,6 @@ void OgreOculusRender::debugSaveToFile(const char path[])
 		Ogre::TextureManager::getSingleton().getByName("RttTex").getPointer()->getBuffer(0, 0)->getRenderTarget()->writeContentsToFile(path);
 }
 
-Ogre::SceneNode* OgreOculusRender::getCameraInformationNode()
-{
-	return headNode;
-}
 
 Ogre::Timer* OgreOculusRender::getTimer()
 {
@@ -125,22 +119,14 @@ Ogre::Timer* OgreOculusRender::getTimer()
 	return nullptr;
 }
 
-double OgreOculusRender::getUpdateTime()
-{
-	return updateTime;
-}
 
 void OgreOculusRender::recenter()
 {
 	ovr_RecenterTrackingOrigin(Oculus->getSession());
 }
 
-void OgreOculusRender::initLibraries(std::string loggerName)
+void OgreOculusRender::initVrHmd()
 {
-	//Create the ogre root with standards Ogre configuration file
-	root = new Ogre::Root("", "ogre.cfg", loggerName.c_str());
-	Ogre::LogManager::getSingleton().setLogDetail(Ogre::LoggingLevel::LL_BOREME);
-	
 	//Class to get basic information from the Rift. Initialize the RiftSDK
 	Oculus = new OculusInterface();
 	hmdSize = Oculus->getHmdDesc().Resolution;
@@ -202,9 +188,9 @@ void OgreOculusRender::initCameras()
 	monoCam->setFOVy(Ogre::Degree(90));
 
 	//VR Eye cameras
-	eyeCameras[left] = smgr->createCamera("lcam");
-	eyeCameras[left]->setPosition(headPosition);
-	eyeCameras[left]->setAutoAspectRatio(true);
+	eyeCameras[left ] = smgr->createCamera("lcam");
+	eyeCameras[left ]->setPosition(headPosition);
+	eyeCameras[left ]->setAutoAspectRatio(true);
 	eyeCameras[right] = smgr->createCamera("rcam");
 	eyeCameras[right]->setPosition(headPosition);
 	eyeCameras[right]->setAutoAspectRatio(true);
@@ -221,6 +207,11 @@ void OgreOculusRender::setMonoFov(float degreeFov)
 void OgreOculusRender::setCamerasNearClippingDistance(float distance)
 {
 	nearClippingDistance = distance;
+}
+
+void OgreOculusRender::setCameraFarClippingDistance(float distance)
+{
+	farClippingDistance = distance;
 }
 
 void OgreOculusRender::initScene()
@@ -307,7 +298,7 @@ void OgreOculusRender::initRttRendering()
 	AnnDebug() << "Using GLEW version : " << glewGetString(GLEW_VERSION);
 
 	//Get texture size from ovr with the maximal FOV for each eye
-	ovrSizei texSizeL = ovr_GetFovTextureSize(Oculus->getSession(), ovrEye_Left, Oculus->getHmdDesc().DefaultEyeFov[left], 1.f);
+	ovrSizei texSizeL = ovr_GetFovTextureSize(Oculus->getSession(), ovrEye_Left , Oculus->getHmdDesc().DefaultEyeFov[left ], 1.f);
 	ovrSizei texSizeR = ovr_GetFovTextureSize(Oculus->getSession(), ovrEye_Right, Oculus->getHmdDesc().DefaultEyeFov[right], 1.f);
 	
 	//Calculate the render buffer size for both eyes
@@ -345,7 +336,7 @@ void OgreOculusRender::initRttRendering()
 	renderTextureGLID = gltex->getGLID();
 
 	//Create viewports on the texture to render the eyeCameras
-	vpts[left]  = rttEyes->addViewport(eyeCameras[left],  0, 0,    0, 0.5f);
+	vpts[left]  = rttEyes->addViewport(eyeCameras[left ], 0,    0, 0, 0.5f);
 	vpts[right] = rttEyes->addViewport(eyeCameras[right], 1, 0.5f, 0, 0.5f);
 
 	changeViewportBackgroundColor(backgroundColor);
@@ -384,9 +375,9 @@ void OgreOculusRender::showRawView()
 {
 	mirrorHMDView = false;
 	if(!debugTexturePlane) return;
-	self->debugViewport->setCamera(self->debugCam);
+	OculusSelf->debugViewport->setCamera(OculusSelf->debugCam);
 	debugTexturePlane->setTextureName("RttTex");
-	self->debugViewport->setBackgroundColour(self->backgroundColor.getOgreColor());
+	OculusSelf->debugViewport->setBackgroundColour(OculusSelf->backgroundColor);
 	AnnDebug() << "Switched to Raw view";
 }
 
@@ -394,22 +385,22 @@ void OgreOculusRender::showMirrorView()
 {
 	mirrorHMDView = true;
 	if(!debugTexturePlane) return;
-	self->debugViewport->setCamera(self->debugCam);
+	OculusSelf->debugViewport->setCamera(OculusSelf->debugCam);
 	debugTexturePlane->setTextureName("MirrorTex");
-	self->debugViewport->setBackgroundColour(Ogre::ColourValue::Black);
+	OculusSelf->debugViewport->setBackgroundColour(Ogre::ColourValue::Black);
 	AnnDebug() << "Switched to Oculus Compositor view";
 }
 
 void OgreOculusRender::showMonscopicView()
 {
 	mirrorHMDView = false;
-	if(!self) return;
-	self->debugViewport->setCamera(self->monoCam);
-	self->debugViewport->setBackgroundColour(self->backgroundColor.getOgreColor());
+	if(!OculusSelf) return;
+	OculusSelf->debugViewport->setCamera(OculusSelf->monoCam);
+	OculusSelf->debugViewport->setBackgroundColour(OculusSelf->backgroundColor);
 	AnnDebug() << "Switched to Monoscopic view";
 }
 
-void OgreOculusRender::initOculus()
+void OgreOculusRender::initClientHmdRendering()
 {
 	//Populate OVR structures
 	EyeRenderDesc[left ] = ovr_GetRenderDesc(Oculus->getSession(), ovrEye_Left , Oculus->getHmdDesc().DefaultEyeFov[left ]);
@@ -476,6 +467,16 @@ ovrSessionStatus OgreOculusRender::getSessionStatus()
 {
 	ovr_GetSessionStatus(Oculus->getSession(), &sessionStatus);
 	return sessionStatus;
+}
+
+void OgreOculusRender::initPipeline()
+{
+	getOgreConfig();
+	createWindow();
+	initScene();
+	initCameras();
+	setCamerasNearClippingDistance();
+	initRttRendering();
 }
 
 void OgreOculusRender::updateTracking()

--- a/src/OgreOculusRender.cpp
+++ b/src/OgreOculusRender.cpp
@@ -479,6 +479,16 @@ void OgreOculusRender::initPipeline()
 	initRttRendering();
 }
 
+bool OgreOculusRender::usesCustomAudioDevice()
+{
+	return true;
+}
+
+std::string OgreOculusRender::getAudioDeviceIdentifierSubString()
+{
+	return std::string("Rift Audio");
+}
+
 void OgreOculusRender::updateTracking()
 {
 	//Get current camera base information

--- a/src/OgreVRRender.cpp
+++ b/src/OgreVRRender.cpp
@@ -22,6 +22,9 @@ OgreVRRender::OgreVRRender(std::string windowName) :
 		exit(ANN_ERR_RENDER);
 	}
 	self = this;
+
+	eyeCameras[0] = nullptr;
+	eyeCameras[1] = nullptr;
 }
 
 OgreVRRender::~OgreVRRender()

--- a/src/OgreVRRender.cpp
+++ b/src/OgreVRRender.cpp
@@ -1,0 +1,70 @@
+#include "stdafx.h"
+#include "OgreVRRender.hpp"
+
+OgreVRRender* OgreVRRender::self = nullptr;
+
+OgreVRRender::OgreVRRender(std::string windowName) :
+	root(nullptr),
+	smgr(nullptr),
+	window(nullptr),
+	updateTime(0),
+	headPosition(0, 0, 10),
+	headOrientation(Ogre::Quaternion::IDENTITY),
+	nearClippingDistance(0.5f),
+	farClippingDistance(4000.0f),
+	headNode(nullptr),
+	backgroundColor(0, 0.56f, 1),
+	name(windowName)
+{
+	if (self)
+	{
+		MessageBox(NULL, L"Fatal error with renderer initialisation. OgreOculusRender object allready created.", L"Fatal Error", MB_ICONERROR);
+		exit(ANN_ERR_RENDER);
+	}
+	self = this;
+	std::cerr <<  "OGRE VR renderer created... ";
+}
+
+OgreVRRender::~OgreVRRender()
+{
+}
+
+Ogre::SceneManager* OgreVRRender::getSceneManager()
+{
+	return smgr;
+}
+
+Ogre::Root* OgreVRRender::getRoot()
+{
+	return root;
+}
+
+Ogre::RenderWindow* OgreVRRender::getWindow()
+{
+	return window;
+}
+
+Ogre::SceneNode * OgreVRRender::getCameraInformationNode()
+{
+	return headNode;
+}
+
+Ogre::Timer * OgreVRRender::getTimer()
+{
+	if (root) return root->getTimer();
+	return nullptr;
+}
+
+double OgreVRRender::getUpdateTime()
+{
+	return updateTime;
+}
+
+void OgreVRRender::initOgreRoot(std::string loggerName)
+{
+	//Create the ogre root with standards Ogre configuration file
+	root = new Ogre::Root("", "ogre.cfg", loggerName.c_str());
+	Ogre::LogManager::getSingleton().setLogDetail(Ogre::LoggingLevel::LL_BOREME);
+}
+
+

--- a/src/OgreVRRender.cpp
+++ b/src/OgreVRRender.cpp
@@ -22,7 +22,6 @@ OgreVRRender::OgreVRRender(std::string windowName) :
 		exit(ANN_ERR_RENDER);
 	}
 	self = this;
-	std::cerr <<  "OGRE VR renderer created... ";
 }
 
 OgreVRRender::~OgreVRRender()


### PR DESCRIPTION
Add an abstraction layer between the engine itself and the peice of code that implements rendering for the Oculus HMD. An interface called "OgreVRRender" is used for that. 

The engine code doesn't reference anything from a specifig HMD, therefore, it is possible to make it render to a different target without changing anything. The only lacking point for that is to load the "OgreVRRender"-child class dynamically during runtime, and therefore not requireing EVERY "client library" to be linked to one program. 

Probably more things can move from the current only child "OgreOculusRender" to it's abstract parent, but the groundwork is here.