### PR TITLE
FSAA_HACK

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -22,6 +22,7 @@ AnnMain()
 	//Only useful on windows : Open a debug console to get stdout/stderr
 	AnnEngine::openConsole();
 
+	OgreVRRender::HACK_BigBufferAA = true;
 	AnnInit("AnnTest");
 
 	//Init some player body parameters

--- a/include/OgreOculusRender.hpp
+++ b/include/OgreOculusRender.hpp
@@ -134,6 +134,7 @@ public:
 	void showDebug(DebugMode mode);
 
 private:
+
 	///Pointer to the renderer itself, re-casted as this class, not the parent
 	static OgreOculusRender* OculusSelf;
 

--- a/include/OgreVRRender.hpp
+++ b/include/OgreVRRender.hpp
@@ -27,6 +27,8 @@ struct OgrePose
 class DLL OgreVRRender
 {
 public:
+	///Put this to true to use a bigger intermediate buffer instead of a *normal* Anti Aliasing method
+	static bool HACK_BigBufferAA;
 
 	///Type of Debug render you can do
 	enum DebugMode
@@ -146,6 +148,7 @@ public:
 	size_t getHanControllerArraySize();
 
 protected:
+
 	///Singleton pointer
 	static OgreVRRender* self;
 

--- a/msvc/test/test.vcxproj.user
+++ b/msvc/test/test.vcxproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerWorkingDirectory>../../example/</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-rift</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-noVR</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LocalDebuggerCommandArguments>

--- a/msvc/test/test.vcxproj.user
+++ b/msvc/test/test.vcxproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerWorkingDirectory>../../example/</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
-    <LocalDebuggerCommandArguments>-noVR</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-rift</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LocalDebuggerCommandArguments>

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -101,7 +101,7 @@ AnnEngine::AnnEngine(const char title[], std::string hmdCommand) :
 	renderer->initPipeline();
 	SceneManager = renderer->getSceneManager();
 
-	renderer->showDebug(OgreVRRender::DebugMode::MONOSCOPIC);
+	renderer->showDebug(OgreVRRender::DebugMode::RAW_BUFFER);
 
 	log("Setup Annwvyn's subsystems");
 

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -101,7 +101,7 @@ AnnEngine::AnnEngine(const char title[], std::string hmdCommand) :
 	renderer->initPipeline();
 	SceneManager = renderer->getSceneManager();
 
-	renderer->showDebug(OgreVRRender::DebugMode::RAW_BUFFER);
+	renderer->showDebug(OgreVRRender::DebugMode::MONOSCOPIC);
 
 	log("Setup Annwvyn's subsystems");
 

--- a/src/OgreNoVRRender.cpp
+++ b/src/OgreNoVRRender.cpp
@@ -33,9 +33,10 @@ void OgreNoVRRender::createWindow()
 	misc["vsync"] = "true";
 	misc["top"] = "0";
 	misc["left"] = "0";
+	misc["FSAA"] = std::to_string(AALevel);
 	root->initialise(false);
 
-	float w(1920 / 2), h(1080 / 2);
+	const float w(1920 / 2), h(1080 / 2);
 
 	window = root->createRenderWindow(name, w, h, false, &misc);
 }

--- a/src/OgreOpenVRRender.cpp
+++ b/src/OgreOpenVRRender.cpp
@@ -310,6 +310,16 @@ void OgreOpenVRRender::initRttRendering()
 	unsigned int w, h;
 	vrSystem->GetRecommendedRenderTargetSize(&w, &h);
 	w *= 2;
+
+	if (HACK_BigBufferAA)
+	{
+		if (AALevel / 2 > 0)
+		{
+			w *= AALevel / 2;
+			h *= AALevel / 2;
+		}
+	}
+
 	Annwvyn::AnnDebug() << "Recommended Render Target Size : " << w << "x" << h;
 
 	//Create theses textures in OpenGL and get their OpenGL ID

--- a/src/OgreVRRender.cpp
+++ b/src/OgreVRRender.cpp
@@ -2,6 +2,7 @@
 #include "OgreVRRender.hpp"
 
 OgreVRRender* OgreVRRender::self = nullptr;
+bool OgreVRRender::HACK_BigBufferAA(false);
 
 OgreVRRender::OgreVRRender(std::string windowName) :
 	root(nullptr),
@@ -16,7 +17,7 @@ OgreVRRender::OgreVRRender(std::string windowName) :
 	backgroundColor(0, 0.56f, 1),
 	name(windowName),
 	frameCounter(0),
-	AALevel(16U)
+	AALevel(4)
 {
 	if (self)
 	{


### PR DESCRIPTION
if wanted, the user can activate a hack that will increase the size of the render buffer according to the AA level set on the VRRender by calling 

`OgreVRRender::HACK_BigBufferAA = true:`

Not enabled by default. 