### PR TITLE
Object parenting

### DIFF
--- a/example/TestLevel.hpp
+++ b/example/TestLevel.hpp
@@ -68,7 +68,7 @@ public:
 		auto Gizmo = AnnGetGameObjectManager()->createGameObject("Gizmo.mesh", "Gizmo");
 		S->attachChildObject(Gizmo);
 		Gizmo->setScale(10, 10, 10);
-		Gizmo->setUpPhysics(10, boxShape);
+		//Gizmo->setUpPhysics(10, boxShape);
 		S->setUpPhysics(10, boxShape);
 
 		//Add water

--- a/example/TestLevel.hpp
+++ b/example/TestLevel.hpp
@@ -66,9 +66,18 @@ public:
 		S->attachScript("DummyBehavior");
 
 		auto Gizmo = AnnGetGameObjectManager()->createGameObject("Gizmo.mesh", "Gizmo");
+		auto ChildGizmo = AnnGetGameObjectManager()->createGameObject("Gizmo.mesh", "ChildGizmo");
+		Gizmo->attachChildObject(ChildGizmo);
+		ChildGizmo->setPosition(1, 1, 1);
+
+		//S is parent
+		//Gizmo is child
 		S->attachChildObject(Gizmo);
 		Gizmo->setScale(10, 10, 10);
-		//Gizmo->setUpPhysics(10, boxShape);
+
+		//If both of theses lines are run, the 2nd one will crash the engine
+		//ChildGizmo->setUpPhysics(10, boxShape);
+
 		S->setUpPhysics(10, boxShape);
 
 		//Add water
@@ -124,7 +133,8 @@ class PhysicsDebugLevel : LEVEL
 		AnnGetPlayer()->resetPlayerPhysics();
 	}
 
-	void runLogic() override {
+	void runLogic() override
+	{
 		AnnDebug() << "Player position is : " << AnnGetPlayer()->getPosition();
 	}
 };

--- a/example/TestLevel.hpp
+++ b/example/TestLevel.hpp
@@ -16,7 +16,7 @@ public:
 		setAnimation("Dance");
 		playAnimation(true);
 		loopAnimation(true);
-		setUpPhysics(40, boxShape);
+		//setUpPhysics(40, boxShape);
 	}
 
 	void atRefresh() override
@@ -68,6 +68,8 @@ public:
 		auto Gizmo = AnnGetGameObjectManager()->createGameObject("Gizmo.mesh", "Gizmo");
 		S->attachChildObject(Gizmo);
 		Gizmo->setScale(10, 10, 10);
+		Gizmo->setUpPhysics(10, boxShape);
+		S->setUpPhysics(10, boxShape);
 
 		//Add water
 		auto Water = addGameObject("environment/Water.mesh");

--- a/example/TestLevel.hpp
+++ b/example/TestLevel.hpp
@@ -65,6 +65,16 @@ public:
 		S->playSound("media/monster.wav", true, 1);
 		S->attachScript("DummyBehavior");
 
+		auto Gizmo = AnnGetGameObjectManager()->createGameObject("Gizmo.mesh", "Gizmo");
+		//S->attachChildObject(Gizmo);
+		//Gizmo->setUpPhysics(10, sphereShape);
+		//Gizmo->setScale(10, 10, 10);
+
+		Gizmo->setPosition(0, 0, -4);
+		Gizmo->attachChildObject(S);
+
+		//Gizmo->setPosition(S->getPosition() + AnnVect3{ 0.0f, 1.0f, 0.0f });
+
 		//Add water
 		auto Water = addGameObject("environment/Water.mesh");
 

--- a/example/TestLevel.hpp
+++ b/example/TestLevel.hpp
@@ -66,14 +66,8 @@ public:
 		S->attachScript("DummyBehavior");
 
 		auto Gizmo = AnnGetGameObjectManager()->createGameObject("Gizmo.mesh", "Gizmo");
-		//S->attachChildObject(Gizmo);
-		//Gizmo->setUpPhysics(10, sphereShape);
-		//Gizmo->setScale(10, 10, 10);
-
-		Gizmo->setPosition(0, 0, -4);
-		Gizmo->attachChildObject(S);
-
-		//Gizmo->setPosition(S->getPosition() + AnnVect3{ 0.0f, 1.0f, 0.0f });
+		S->attachChildObject(Gizmo);
+		Gizmo->setScale(10, 10, 10);
 
 		//Add water
 		auto Water = addGameObject("environment/Water.mesh");

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -17,7 +17,7 @@
 using namespace std;
 using namespace Annwvyn;
 
-bool isRoomscale{ true };
+constexpr bool isRoomscale{ false };
 
 AnnMain()
 {

--- a/include/AnnException.hpp
+++ b/include/AnnException.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "systemMacro.h"
+#include <sstream>
+#include <exception>
+#include <stdexcept>
+#include <AnnGameObject.hpp>
+namespace Annwvyn
+{
+	///Exception to throw when a physics enabled object will cause object coordinates reset
+	class DLL AnnPhysicsSetupParentError : public std::runtime_error
+	{
+	public:
+		AnnPhysicsSetupParentError(AnnGameObject* origin);
+
+		///Pretty text to explain what's wrong
+		const char* what() const throw() override;
+
+		AnnGameObject* getObject() const;
+
+		AnnGameObject* getParentWithBody() const;
+
+	private:
+		AnnGameObject* recurToBody(AnnGameObject* start) const;
+		AnnGameObject* objectWithProblem;
+		static std::ostringstream outputFormater;
+	};
+}

--- a/include/AnnException.hpp
+++ b/include/AnnException.hpp
@@ -25,4 +25,13 @@ namespace Annwvyn
 		AnnGameObject* objectWithProblem;
 		static std::ostringstream outputFormater;
 	};
+
+	class DLL AnnPhysicsSetupChildError : public std::runtime_error
+	{
+	public:
+		AnnPhysicsSetupChildError(AnnGameObject* origin);
+		const char* what() const throw() override;
+	private:
+		AnnGameObject* objectWithProblem;
+	};
 }

--- a/include/AnnGameObject.hpp
+++ b/include/AnnGameObject.hpp
@@ -171,7 +171,12 @@ namespace Annwvyn
 		///Make the node independent to any GameObject
 		void detachFromParent();
 
+		bool checkForBodyInParent();
+
 	private:
+
+		bool parentsHaveBody(AnnGameObject* obj);
+
 		///Make Annwvyn::AnnEngine access these methods :
 		friend class AnnEngine;
 		friend class AnnGameObjectManager;

--- a/include/AnnGameObject.hpp
+++ b/include/AnnGameObject.hpp
@@ -30,7 +30,6 @@
 
 namespace Annwvyn
 {
-	class DLL AnnGameObject;
 	class DLL AnnGameObjectManager;
 
 	///An object that exist in the game. Graphically and Potentially Physically
@@ -57,7 +56,10 @@ namespace Annwvyn
 		/// \param pos 3D position vector. Relative to scene root position
 		void setPosition(AnnVect3 pos) override;
 
+		///Set the world position from a vector
 		void setWorldPosition(AnnVect3 pos);
+
+		///Set the world position from a few floats
 		void setWorldPosition(float x, float y, float z);
 
 		///Translate
@@ -77,7 +79,10 @@ namespace Annwvyn
 		/// \param orient Quaternion for absolute orientation
 		void setOrientation(AnnQuaternion orient) override;
 
+		///Set the world orientation as a quaternion
 		void setWorldOrientation(AnnQuaternion orient);
+
+		///Set the world orientation as some floats
 		void setWorldOrientation(float w, float x, float y, float z);
 
 		///Set scale
@@ -93,11 +98,13 @@ namespace Annwvyn
 		///Get Position
 		AnnVect3 getPosition() override;
 
+		///Get the position in world
 		AnnVect3 getWorldPosition();
 
 		///Get Orientation
 		AnnQuaternion getOrientation() override;
 
+		///Get the world orientation
 		AnnQuaternion getWorldOrientation();
 
 		///Get scale
@@ -165,7 +172,7 @@ namespace Annwvyn
 		///Attach a script to this object
 		void attachScript(const std::string& scriptName);
 
-		///Return true if node is attached to the node of a GameObject. Nodes present in the scene allays have a parent, the Root node. It will be treated as 'not attached to parent' if attached to scene root
+		///Return true if node is attached to the node owned by another AnnGameObject
 		bool hasParent();
 
 		///Get the parent Game Object
@@ -177,12 +184,18 @@ namespace Annwvyn
 		///Make the node independent to any GameObject
 		void detachFromParent();
 
+		///Recursively check if any parent has a body, if one is found, returns true
 		bool checkForBodyInParent();
+
+		///Recursively check if any child has a body, if one is found, returns true
 		bool checkForBodyInChild();
 
 	private:
 
+		///Do the actual recursion of checkForBodyInParent
 		bool parentsHaveBody(AnnGameObject* obj);
+
+		///Do the actual recursion of checkForBodyInChild
 		bool childrenHaveBody(AnnGameObject* obj);
 
 		///Make Annwvyn::AnnEngine access these methods :
@@ -211,7 +224,10 @@ namespace Annwvyn
 		* Same is true with the Orientation. We use Ogre node
 		*/
 
+		///SceneNode
 		Ogre::SceneNode* Node;
+
+		///Entity
 		Ogre::Entity* Entity;
 
 		// TODO create animation state machine
@@ -232,6 +248,7 @@ namespace Annwvyn
 		///True if the object is visible
 		BtOgre::RigidBodyState *state;
 
+		///list of script objects
 		std::vector<std::shared_ptr<AnnBehaviorScript>> scripts;
 
 	public:

--- a/include/AnnGameObject.hpp
+++ b/include/AnnGameObject.hpp
@@ -57,6 +57,9 @@ namespace Annwvyn
 		/// \param pos 3D position vector. Relative to scene root position
 		void setPosition(AnnVect3 pos) override;
 
+		void setWorldPosition(AnnVect3 pos);
+		void setWorldPosition(float x, float y, float z);
+
 		///Translate
 		/// \param x X component of the translation vector
 		/// \param y Y component of the translation vector
@@ -73,6 +76,9 @@ namespace Annwvyn
 		///Set Orientation from Quaternion
 		/// \param orient Quaternion for absolute orientation
 		void setOrientation(AnnQuaternion orient) override;
+
+		void setWorldOrientation(AnnQuaternion orient);
+		void setWorldOrientation(float w, float x, float y, float z);
 
 		///Set scale
 		/// \param x X component of the scale vector

--- a/include/AnnGameObject.hpp
+++ b/include/AnnGameObject.hpp
@@ -172,6 +172,7 @@ namespace Annwvyn
 		void detachFromParent();
 
 		bool checkForBodyInParent();
+		bool checkForBodyInChild();
 
 	private:
 

--- a/include/AnnGameObject.hpp
+++ b/include/AnnGameObject.hpp
@@ -183,6 +183,7 @@ namespace Annwvyn
 	private:
 
 		bool parentsHaveBody(AnnGameObject* obj);
+		bool childrenHaveBody(AnnGameObject* obj);
 
 		///Make Annwvyn::AnnEngine access these methods :
 		friend class AnnEngine;

--- a/include/AnnGameObject.hpp
+++ b/include/AnnGameObject.hpp
@@ -87,8 +87,12 @@ namespace Annwvyn
 		///Get Position
 		AnnVect3 getPosition() override;
 
+		AnnVect3 getWorldPosition();
+
 		///Get Orientation
 		AnnQuaternion getOrientation() override;
+
+		AnnQuaternion getWorldOrientation();
 
 		///Get scale
 		AnnVect3 getScale();
@@ -154,6 +158,18 @@ namespace Annwvyn
 
 		///Attach a script to this object
 		void attachScript(const std::string& scriptName);
+
+		///Return true if node is attached to the node of a GameObject. Nodes present in the scene allays have a parent, the Root node. It will be treated as 'not attached to parent' if attached to scene root
+		bool hasParent();
+
+		///Get the parent Game Object
+		std::shared_ptr<AnnGameObject> getParent();
+
+		///Attach an object to this object.
+		void attachChildObject(std::shared_ptr<AnnGameObject> child);
+
+		///Make the node independent to any GameObject
+		void detachFromParent();
 
 	private:
 		///Make Annwvyn::AnnEngine access these methods :

--- a/include/AnnPlayer.hpp
+++ b/include/AnnPlayer.hpp
@@ -155,7 +155,7 @@ namespace Annwvyn
 
 		///Boolean false if the player can get orientation transformation from
 		bool standing;
-
+		float mouseSensitivity;
 		///Get the ratio between walking and running speed
 		float getRunFactor();
 

--- a/include/Annwvyn.h
+++ b/include/Annwvyn.h
@@ -95,6 +95,7 @@
 #include "AnnResourceManager.hpp"
 #include "Ann3DTextPlane.hpp"
 #include "AnnUserSpaceSubSystem.hpp"
+#include "AnnException.hpp"
 
 //Other Annwvyn
 #include "AnnTypes.h"
@@ -147,7 +148,7 @@ namespace Annwvyn
 		std::cout << "ANNWVYN DEVEL\n";
 		std::cout << "Console output enabled\n";
 #endif
-	}
+}
 
 	inline void postQuit()
 	{

--- a/include/BtOgrePG.h
+++ b/include/BtOgrePG.h
@@ -69,8 +69,13 @@ namespace BtOgre {
 
 			btQuaternion rot = transform.getRotation();
 			btVector3 pos = transform.getOrigin();
-			mNode->setOrientation(rot.w(), rot.x(), rot.y(), rot.z());
-			mNode->setPosition(pos.x(), pos.y(), pos.z());
+
+			//Hack by Ybalrid : move the world transform instead of the `relative to parent one
+			Ogre::Vector3 ogrePos(pos.x(), pos.y(), pos.z());
+			Ogre::Quaternion ogreRot(rot.w(), rot.x(), rot.y(), rot.z());
+
+			mNode->_setDerivedOrientation(ogreRot);
+			mNode->_setDerivedPosition(ogrePos);
 		}
 
 		void setNode(Ogre::SceneNode *node)

--- a/msvc/Annwvyn/Annwvyn.vcxproj
+++ b/msvc/Annwvyn/Annwvyn.vcxproj
@@ -184,6 +184,7 @@ COPY "$(TargetDir)\Annwvyn.pdb" "$(TargetDir)\..\template\"
     <ClInclude Include="..\..\include\AnnAbstractMovable.hpp" />
     <ClInclude Include="..\..\include\AnnAngle.hpp" />
     <ClInclude Include="..\..\include\Ann3DTextPlane.hpp" />
+    <ClInclude Include="..\..\include\AnnException.hpp" />
     <ClInclude Include="..\..\include\AnnGetter.hpp" />
     <ClInclude Include="..\..\include\AnnHandController.hpp" />
     <ClInclude Include="..\..\include\AnnLevel.hpp" />
@@ -238,6 +239,7 @@ COPY "$(TargetDir)\Annwvyn.pdb" "$(TargetDir)\..\template\"
     </ClCompile>
     <ClCompile Include="..\..\src\AnnAngle.cpp" />
     <ClCompile Include="..\..\src\Ann3DTextPlane.cpp" />
+    <ClCompile Include="..\..\src\AnnException.cpp" />
     <ClCompile Include="..\..\src\AnnGetter.cpp" />
     <ClCompile Include="..\..\src\AnnHandController.cpp" />
     <ClCompile Include="..\..\src\AnnLevel.cpp" />

--- a/msvc/Annwvyn/Annwvyn.vcxproj.filters
+++ b/msvc/Annwvyn/Annwvyn.vcxproj.filters
@@ -249,6 +249,9 @@
     <ClInclude Include="..\..\include\AnnGetter.hpp">
       <Filter>Annwvyn\Core\Utility</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\AnnException.hpp">
+      <Filter>Annwvyn\Core\Utility</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\pch\stdafx.cpp">
@@ -366,6 +369,9 @@
       <Filter>Annwvyn\SubSystems\Scripting</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\AnnGetter.cpp">
+      <Filter>Annwvyn\Core\Utility</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\AnnException.cpp">
       <Filter>Annwvyn\Core\Utility</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/AnnException.cpp
+++ b/src/AnnException.cpp
@@ -1,0 +1,46 @@
+#include "stdafx.h"
+#include "AnnException.hpp"
+#include "AnnLogger.hpp"
+
+using namespace std;
+using namespace Annwvyn;
+
+ostringstream AnnPhysicsSetupParentError::outputFormater;
+
+AnnPhysicsSetupParentError::AnnPhysicsSetupParentError(AnnGameObject* origin) :
+	runtime_error{ "Cannot setup physics for object " },
+	objectWithProblem{ origin }
+{
+	AnnDebug() << AnnPhysicsSetupParentError::what();
+}
+
+const char* AnnPhysicsSetupParentError::what() const throw()
+{
+	outputFormater.str("");
+
+	outputFormater << runtime_error::what() << " : " << objectWithProblem->getName();
+
+	if (objectWithProblem->hasParent())
+	{
+		outputFormater << " child of : " << objectWithProblem->getParent()->getName() << '\n';
+		outputFormater << "The parent with a physics body is : " << getParentWithBody()->getName();
+	}
+
+	outputFormater << "\nSetting up physics of a child object with parent"
+		" break the parent/transform derivation because the Physics engine"
+		" move object in world position.";
+
+	outputFormater << "\n Consider not parenting theses two object if you want them to be independent physics objects.";
+
+	return outputFormater.str().c_str();
+}
+
+AnnGameObject* AnnPhysicsSetupParentError::getObject() const { return objectWithProblem; }
+
+AnnGameObject* AnnPhysicsSetupParentError::getParentWithBody() const { return recurToBody(objectWithProblem); }
+
+AnnGameObject* AnnPhysicsSetupParentError::recurToBody(AnnGameObject* start) const
+{
+	if (start->getParent()->getBody()) return start->getParent().get();
+	return recurToBody(start->getParent().get());
+}

--- a/src/AnnException.cpp
+++ b/src/AnnException.cpp
@@ -44,3 +44,20 @@ AnnGameObject* AnnPhysicsSetupParentError::recurToBody(AnnGameObject* start) con
 	if (start->getParent()->getBody()) return start->getParent().get();
 	return recurToBody(start->getParent().get());
 }
+
+AnnPhysicsSetupChildError::AnnPhysicsSetupChildError(AnnGameObject* origin) :
+	runtime_error{ "Cannot setup physics for Object " },
+	objectWithProblem{ origin }
+{
+	AnnDebug() << AnnPhysicsSetupChildError::what();
+}
+
+const char* AnnPhysicsSetupChildError::what() const throw()
+{
+	ostringstream out;
+	out << runtime_error::what();
+	out << objectWithProblem->getName() << '\n';
+	out << "a child has a rigid body. Creating a body will mess up the system. consider not using parenting for theses objects";
+
+	return out.str().c_str();
+}

--- a/src/AnnGameObject.cpp
+++ b/src/AnnGameObject.cpp
@@ -75,7 +75,7 @@ void AnnGameObject::callUpdateOnScripts()
 
 void AnnGameObject::setPosition(float x, float y, float z)
 {
-	setPosition(AnnVect3{ x,y,z });
+	setPosition(AnnVect3{ x, y, z });
 }
 
 void AnnGameObject::translate(float x, float y, float z)
@@ -141,7 +141,7 @@ void AnnGameObject::setScale(AnnVect3 scale)
 
 void AnnGameObject::setWorldOrientation(float w, float x, float y, float z)
 {
-	setWorldOrientation(AnnQuaternion{ w,x,y,z });
+	setWorldOrientation(AnnQuaternion{ w, x, y, z });
 }
 
 void AnnGameObject::setScale(float x, float y, float z)
@@ -333,15 +333,15 @@ bool AnnGameObject::hasParent()
 {
 	auto parentSceneNode = Node->getParentSceneNode();
 
-	AnnDebug() << this << " " << getName() << " is testing for parent";
-	AnnDebug() << "Our node is" << Node;
-	AnnDebug() << "Parent node is " << parentSceneNode;
-	AnnDebug() << "Root node is " << AnnGetEngine()->getSceneManager()->getRootSceneNode();
+	//AnnDebug() << this << " " << getName() << " is testing for parent";
+	//AnnDebug() << "Our node is" << Node;
+	//AnnDebug() << "Parent node is " << parentSceneNode;
+	//AnnDebug() << "Root node is " << AnnGetEngine()->getSceneManager()->getRootSceneNode();
 
 	if (reinterpret_cast<uint64_t>(parentSceneNode)
 		== reinterpret_cast<uint64_t>(AnnGetEngine()->getSceneManager()->getRootSceneNode()))
 	{
-		AnnDebug() << "we caught the fact that parent scene node is root scene node";
+		//AnnDebug() << "we caught the fact that parent scene node is root scene node";
 		return false;
 	}
 

--- a/src/AnnGameObject.cpp
+++ b/src/AnnGameObject.cpp
@@ -101,7 +101,13 @@ void AnnGameObject::setPosition(AnnVect3 pos)
 	Node->setPosition(pos);
 
 	//change OpenAL Source Position
-	audioSource->setPositon(pos);
+	updateOpenAlPos();
+}
+
+void AnnGameObject::setWorldPosition(AnnVect3 pos)
+{
+	Node->_setDerivedPosition(pos);
+	updateOpenAlPos();
 }
 
 void AnnGameObject::setOrientation(float w, float x, float y, float z)
@@ -123,9 +129,19 @@ void AnnGameObject::setOrientation(AnnQuaternion orient)
 	}
 }
 
+void AnnGameObject::setWorldOrientation(AnnQuaternion orient)
+{
+	Node->_setDerivedOrientation(orient);
+}
+
 void AnnGameObject::setScale(AnnVect3 scale)
 {
 	Node->setScale(scale);
+}
+
+void AnnGameObject::setWorldOrientation(float w, float x, float y, float z)
+{
+	setWorldOrientation(AnnQuaternion{ w,x,y,z });
 }
 
 void AnnGameObject::setScale(float x, float y, float z)
@@ -384,16 +400,18 @@ bool AnnGameObject::checkForBodyInChild()
 	for (auto childNode : Node->getChildIterator())
 	{
 		auto node = childNode.second;
-		Ogre::SceneNode* childSceneNode;
-		if (dynamic_cast<Ogre::SceneNode*>(node))
+		Ogre::SceneNode* childSceneNode = dynamic_cast<Ogre::SceneNode*>(node);
+		if (childSceneNode != nullptr)
 		{
-			childSceneNode = dynamic_cast<Ogre::SceneNode*>(node);
 			auto obj = AnnGetGameObjectManager()->getFromNode(childSceneNode);
-			if (obj)
-				if (obj->getBody())
-					return true;
+			if (obj != nullptr && obj->getBody()) return true;
 		}
 	}
 
 	return false;
+}
+
+void AnnGameObject::setWorldPosition(float x, float y, float z)
+{
+	setWorldPosition(AnnVect3{ x,y,z });
 }

--- a/src/AnnGameObject.cpp
+++ b/src/AnnGameObject.cpp
@@ -338,10 +338,10 @@ bool AnnGameObject::hasParent()
 	AnnDebug() << "Parent node is " << parentSceneNode;
 	AnnDebug() << "Root node is " << AnnGetEngine()->getSceneManager()->getRootSceneNode();
 
-	if (reinterpret_cast<uint64_t>(static_cast<void*>(parentSceneNode))
-		== reinterpret_cast<uint64_t>(static_cast<void*>(AnnGetEngine()->getSceneManager()->getRootSceneNode())))
+	if (reinterpret_cast<uint64_t>(parentSceneNode)
+		== reinterpret_cast<uint64_t>(AnnGetEngine()->getSceneManager()->getRootSceneNode()))
 	{
-		AnnDebug() << "we catched the fact that parent scene node is root scene node";
+		AnnDebug() << "we caught the fact that parent scene node is root scene node";
 		return false;
 	}
 

--- a/src/AnnGameObject.cpp
+++ b/src/AnnGameObject.cpp
@@ -397,14 +397,29 @@ bool AnnGameObject::parentsHaveBody(AnnGameObject* obj)
 
 bool AnnGameObject::checkForBodyInChild()
 {
-	for (auto childNode : Node->getChildIterator())
+	return childrenHaveBody(this);
+}
+
+bool AnnGameObject::childrenHaveBody(AnnGameObject* parentObj)
+{
+	for (auto childNode : parentObj->Node->getChildIterator())
 	{
 		auto node = childNode.second;
-		Ogre::SceneNode* childSceneNode = dynamic_cast<Ogre::SceneNode*>(node);
+		auto childSceneNode = dynamic_cast<Ogre::SceneNode*>(node);
+
+		//Is an actual SceneNode
 		if (childSceneNode != nullptr)
 		{
 			auto obj = AnnGetGameObjectManager()->getFromNode(childSceneNode);
-			if (obj != nullptr && obj->getBody()) return true;
+			//found an object
+			if (obj != nullptr)
+			{
+				//Found a body
+				if (obj->getBody()) return true;
+
+				//Do child recursion here.
+				return childrenHaveBody(obj.get());
+			}
 		}
 	}
 
@@ -413,5 +428,5 @@ bool AnnGameObject::checkForBodyInChild()
 
 void AnnGameObject::setWorldPosition(float x, float y, float z)
 {
-	setWorldPosition(AnnVect3{ x,y,z });
+	setWorldPosition(AnnVect3{ x, y, z });
 }

--- a/src/AnnGameObject.cpp
+++ b/src/AnnGameObject.cpp
@@ -2,6 +2,7 @@
 #include "AnnGameObject.hpp"
 #include "AnnLogger.hpp"
 #include "AnnGetter.hpp"
+#include "AnnException.hpp"
 
 using namespace Annwvyn;
 
@@ -159,6 +160,8 @@ void AnnGameObject::setEntity(Ogre::Entity* newEntity)
 
 void AnnGameObject::setUpPhysics(float mass, phyShapeType type, bool colideWithPlayer)
 {
+	if (checkForBodyInParent()) throw AnnPhysicsSetupParentError(this);
+
 	//init shape converter
 	BtOgre::StaticMeshToShapeConverter converter(Entity);
 
@@ -339,6 +342,11 @@ void AnnGameObject::detachFromParent()
 	AnnGetEngine()->getSceneManager()->getRootSceneNode()->addChild(Node);
 }
 
+bool AnnGameObject::checkForBodyInParent()
+{
+	return parentsHaveBody(this);
+}
+
 AnnVect3 AnnGameObject::getWorldPosition()
 {
 	return Node->_getDerivedPosition();
@@ -347,4 +355,11 @@ AnnVect3 AnnGameObject::getWorldPosition()
 AnnQuaternion AnnGameObject::getWorldOrientation()
 {
 	return Node->_getDerivedOrientation();
+}
+
+bool AnnGameObject::parentsHaveBody(AnnGameObject* obj)
+{
+	if (!hasParent()) return false;
+	if (obj->getParent()->getBody()) return true;
+	return parentsHaveBody(obj->getParent().get());
 }

--- a/src/AnnPlayer.cpp
+++ b/src/AnnPlayer.cpp
@@ -45,6 +45,8 @@ AnnPlayer::AnnPlayer()
 	setActuator(new AnnDefaultPlayerActuator);
 
 	ignorePhysics = false;
+
+	mouseSensitivity = 3;
 }
 
 void AnnPlayer::setActuator(AnnPlayerActuator* act)
@@ -212,6 +214,7 @@ void AnnPlayer::applyRelativeBodyYaw(Ogre::Radian angle)
 
 void AnnPlayer::applyMouseRelativeRotation(int relValue)
 {
+	relValue *= mouseSensitivity;
 	applyRelativeBodyYaw(Ogre::Radian(-float(relValue) * getTurnSpeed() * updateTime));
 }
 

--- a/src/OgreOpenVRRender.cpp
+++ b/src/OgreOpenVRRender.cpp
@@ -188,7 +188,6 @@ void OgreOpenVRRender::renderAndSubmitFrame()
 	window->update();
 
 	//Submit the textures to the SteamVR compositor
-
 	vr::VRCompositor()->Submit(vr::Eye_Left, &vrTextures, &GLBounds[0]);
 	vr::VRCompositor()->Submit(vr::Eye_Right, &vrTextures, &GLBounds[1]);
 


### PR DESCRIPTION
Working on #67 here. 

This merge will add the possibility to attach a game object to another one, making a parent/child relationship. 

This way, moving the parent move the child, moving the child change the relative position orientation of the parent. 

This pose some problems with the physics engine because some situation will makes object behave in ways they shouldn't (drift in position, un-sync of the position of bodies from mesh. etc.) 

I'm implementing exceptions than intends to crash the game and write useful logs to signal when theses situations happens, but basically, don't put physics on parent AND child at the same time. 