### PR TITLE
make the annengine singleton reset himself after the whole destructio…

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -64,6 +64,7 @@ AnnMain()
 
 	/*auto */GameEngine = std::make_unique<AnnEngine>("other app", detectedHMD);
 	AnnGetResourceManager()->initResources();
+	AnnGetEventManager()->useDefaultEventListener();
 	AnnGetEngine()->startGameplayLoop();
 
 	AnnQuit();

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -68,5 +68,7 @@ AnnMain()
 
 	AnnQuit();
 
+	MessageBox(nullptr, L"If it did not crash here, it means that the engine is not in a zombie state when cleared, and is stable!", L"Engine test success!", MB_ICONASTERISK);
+
 	return EXIT_SUCCESS;
 }

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -35,6 +35,7 @@ AnnMain()
 	//load resources
 	AnnGetResourceManager()->addFileLocation("media/environment");
 	AnnGetResourceManager()->addFileLocation("media/debug");
+
 	AnnGetResourceManager()->initResources();
 	//AnnGetResourceManager()->loadGroup(AnnResourceManager::reservedResourceGroupName);
 	//AnnGetResourceManager()->loadGroup(AnnResourceManager::defaultResourceGroupName);
@@ -53,6 +54,16 @@ AnnMain()
 	//stringstream controllerOut;
 	AnnDebug() << "Starting the render loop";
 
+	AnnGetEngine()->startGameplayLoop();
+
+	AnnQuit();
+
+	//Try to start the engine again :
+
+	MessageBox(nullptr, L"Starting Annwvyn again", L"Engine restart", MB_ICONINFORMATION);
+
+	/*auto */GameEngine = std::make_unique<AnnEngine>("other app", detectedHMD);
+	AnnGetResourceManager()->initResources();
 	AnnGetEngine()->startGameplayLoop();
 
 	AnnQuit();

--- a/include/AnnEngine.hpp
+++ b/include/AnnEngine.hpp
@@ -57,6 +57,16 @@
 
 namespace Annwvyn
 {
+	class AnnEngine;
+	class DLL AnnEngineSingletonReseter
+	{
+	private:
+		AnnEngineSingletonReseter(AnnEngine* address);
+		~AnnEngineSingletonReseter();
+		friend class AnnEngine;
+		AnnEngine* engine;
+	};
+
 	///Main engine class. Creating an instance of this class make the engine start.
 	class DLL AnnEngine
 	{
@@ -70,6 +80,8 @@ namespace Annwvyn
 	private:
 		///the singleton address itself is stored here
 		static AnnEngine* singleton;
+		friend class AnnEngineSingletonReseter;
+		AnnEngineSingletonReseter resetGuard;
 
 	public:
 
@@ -141,7 +153,7 @@ namespace Annwvyn
 		///Get the VRRenderer
 		std::shared_ptr<OgreVRRender> getVRRenderer();
 
-		///Get the console 
+		///Get the console
 		std::shared_ptr<AnnConsole> getOnScreenConsole();
 
 		/////////////////////////////////////////////explicit /////////////////////////////////////////////////END OF SUBSYSTEMS
@@ -163,9 +175,6 @@ namespace Annwvyn
 
 		///This start the render loop. This also calls objects "atRefresh" and current level "runLogic" methods each frame
 		void startGameplayLoop();
-
-		///Toggle the display of the in-engine console
-		static void toogleOnScreenConsole();
 
 		///Return true if the app is visible inside the head mounted display
 		bool appVisibleInHMD();
@@ -199,12 +208,13 @@ namespace Annwvyn
 		static WORD consoleGreen;
 		static WORD consoleYellow;
 		static WORD consoleWhite;
+		static bool consoleReady;
 
 		///VR renderer
 		std::shared_ptr<OgreVRRender> renderer;
 
 		///The onScreenConsole object
-		static std::shared_ptr<AnnConsole> onScreenConsole;
+		std::shared_ptr<AnnConsole> onScreenConsole;
 		///ResourceManager
 		std::shared_ptr<AnnResourceManager> resourceManager;
 		///SceneryManager

--- a/include/AnnEngine.hpp
+++ b/include/AnnEngine.hpp
@@ -104,14 +104,14 @@ namespace Annwvyn
 		static void log(std::string message, bool flag = true); //engine
 
 		///Get the player
-		std::shared_ptr<AnnPlayer> getPlayer();
+		std::shared_ptr<AnnPlayer> getPlayer() const;
 
 		///Is key 'key' pressed ? (see OIS headers for KeyCode, generally 'OIS::KC_X' where X is the key you want.
 		/// key an OIS key code
-		bool isKeyDown(OIS::KeyCode key); //event
+		bool isKeyDown(OIS::KeyCode key) const; //event
 
 		///Get ogre camera scene node
-		Ogre::SceneNode* getPlayerPovNode();
+		Ogre::SceneNode* getPlayerPovNode() const;
 
 		///Open a console and redirect standard output to it.
 		///This is only effective on Windows. There is no other
@@ -119,77 +119,77 @@ namespace Annwvyn
 		static bool openConsole();
 
 		///Get ogre scene manager
-		Ogre::SceneManager* getSceneManager(); //scene or graphics
+		Ogre::SceneManager* getSceneManager() const; //scene or graphics
 
 		/////////////////////////////////////////////////////////////////////////////////////////////////////SUBSYSTEMS
 
 		///Get the event manager
-		std::shared_ptr<AnnEventManager> getEventManager();
+		std::shared_ptr<AnnEventManager> getEventManager() const;
 
 		///Get the file-system manager
-		std::shared_ptr<AnnFilesystemManager> getFileSystemManager();
+		std::shared_ptr<AnnFilesystemManager> getFileSystemManager() const;
 
 		///Return the Annwvyn OpenAL simplified audio engine
-		std::shared_ptr<AnnAudioEngine> getAudioEngine(); //audio
+		std::shared_ptr<AnnAudioEngine> getAudioEngine() const; //audio
 
 		///Return the Physics Engine
-		std::shared_ptr<AnnPhysicsEngine> getPhysicsEngine();
+		std::shared_ptr<AnnPhysicsEngine> getPhysicsEngine() const;
 
 		///Get the current level manager
-		std::shared_ptr<AnnLevelManager> getLevelManager();
+		std::shared_ptr<AnnLevelManager> getLevelManager() const;
 
 		///Get the ResourceManager
-		std::shared_ptr<AnnResourceManager> getResourceManager();
+		std::shared_ptr<AnnResourceManager> getResourceManager() const;
 
 		///Get the GameObjectManager
-		std::shared_ptr<AnnGameObjectManager> getGameObjectManager();
+		std::shared_ptr<AnnGameObjectManager> getGameObjectManager() const;
 
 		///Get the SceneryManager
-		std::shared_ptr<AnnSceneryManager> getSceneryManager();
+		std::shared_ptr<AnnSceneryManager> getSceneryManager() const;
 
 		///Get the ScriptManager
-		std::shared_ptr<AnnScriptManager> getScriptManager();
+		std::shared_ptr<AnnScriptManager> getScriptManager() const;
 
 		///Get the VRRenderer
-		std::shared_ptr<OgreVRRender> getVRRenderer();
+		std::shared_ptr<OgreVRRender> getVRRenderer() const;
 
 		///Get the console
-		std::shared_ptr<AnnConsole> getOnScreenConsole();
+		std::shared_ptr<AnnConsole> getOnScreenConsole() const;
 
 		/////////////////////////////////////////////explicit /////////////////////////////////////////////////END OF SUBSYSTEMS
 
 		///Init the physics model
-		DEPRECATED void initPlayerPhysics(); //physics on player
-		void initPlayerStandingPhysics();
+		DEPRECATED void initPlayerPhysics() const; //physics on player
+		void initPlayerStandingPhysics() const;
 
-		void initPlayerRoomscalePhysics();
+		void initPlayerRoomscalePhysics() const;
 
 		///Return true if the game want to terminate the program
-		bool requestStop(); //engine
+		bool requestStop() const; //engine
 
 		///Refresh all for you
 		bool refresh(); //engine main loop
 
 		///Set the POV node to the AnnPlayer gameplay defined position/orientation of the player's body
-		void syncPov();
+		void syncPov() const;
 
 		///This start the render loop. This also calls objects "atRefresh" and current level "runLogic" methods each frame
 		void startGameplayLoop();
 
 		///Return true if the app is visible inside the head mounted display
-		bool appVisibleInHMD();
+		bool appVisibleInHMD() const;
 
 		///Get elapsed time from engine startup in millisecond
-		unsigned long getTimeFromStartUp();//engine
+		unsigned long getTimeFromStartUp() const;//engine
 
 		///Get elapsed time from engine startup in seconds
-		double getTimeFromStartupSeconds();
+		double getTimeFromStartupSeconds() const;
 
 		///Get elapsed time between two frames in seconds
-		double getFrameTime();
+		double getFrameTime() const;
 
 		///Get the pose of the HMD in VR world space
-		OgrePose getHmdPose();
+		OgrePose getHmdPose() const;
 
 		///Register your own subsystem to be updated by the engine
 		std::shared_ptr<AnnUserSubSystem> registerUserSubSystem(std::shared_ptr<AnnUserSubSystem> userSystem);

--- a/include/OgreOculusRender.hpp
+++ b/include/OgreOculusRender.hpp
@@ -139,7 +139,7 @@ private:
 	static OgreOculusRender* OculusSelf;
 
 	///Set the Fov for the monoscopic view
-	void setMonoFov(float degreeFov);
+	void setMonoFov(float degreeFov) const;
 
 	///Object for getting informations from the Oculus Rift
 	OculusInterface* Oculus;
@@ -184,7 +184,7 @@ private:
 	ovrInputState inputState;
 
 	///Array of indexes of buttons. Indexes are fixed signed 32 bits
-	std::array<std::array < int32_t, 4>, 2> touchControllersButtons;
+	std::array<std::array<int32_t, 4>, 2> touchControllersButtons;
 
 	///Tracking state
 	ovrTrackingState ts;
@@ -220,7 +220,7 @@ private:
 	Ogre::Camera* debugCam;
 
 	///Nodes for the debug scene
-	Ogre::SceneNode* debugCamNode, *debugPlaneNode;
+	Ogre::SceneNode *debugCamNode, *debugPlaneNode;
 
 	///Pointer to the debug plane manual material
 	Ogre::MaterialPtr DebugPlaneMaterial;
@@ -262,7 +262,7 @@ private:
 	};
 
 	///Texture coordinates to map a whole texture to the debug plane
-	static constexpr const std::array<const std::array< const float, 2>, 4> debugPlaneTextureCoord
+	static constexpr const std::array<const std::array<const float, 2>, 4> debugPlaneTextureCoord
 	{
 		{
 			{0, 0},
@@ -273,10 +273,10 @@ private:
 	};
 
 	///Index buffer of the debug plane
-	static constexpr const std::array<const uint8_t, 4>debugPlaneIndexBuffer{ 0, 1, 2, 3 };
+	static constexpr const std::array<const uint8_t, 4> debugPlaneIndexBuffer{ 0, 1, 2, 3 };
 
 	///Index buffer of a quad
-	static constexpr const std::array<const uint8_t, 4>quadIndexBuffer{ 0, 1, 2, 3 };
+	static constexpr const std::array<const uint8_t, 4> quadIndexBuffer{ 0, 1, 2, 3 };
 
 	///Preferred order to update eyes
 	static constexpr const std::array<const oorEyeType, 2> eyeUpdateOrder{ {left, right} };

--- a/include/OgreVRRender.hpp
+++ b/include/OgreVRRender.hpp
@@ -26,6 +26,13 @@ struct OgrePose
 class DLL OgreVRRender
 {
 public:
+	///Name of the rendersystem plugin to load on Ogre
+	static constexpr const char* const PluginRenderSystemGL{ "RenderSystem_GL" };
+	///Name of the scene manager plugin to load on ogre
+	static constexpr const char* const PluginOctreeSceneManager{ "Plugin_OctreeSceneManager" };
+	///Name of the rendersystem to initialize
+	static constexpr const char* const GLRenderSystem{ "OpenGL Rendering Subsystem" };
+
 	///Put this to true to use a bigger intermediate buffer instead of a *normal* Anti Aliasing method
 	static bool UseSSAA;
 
@@ -48,25 +55,25 @@ public:
 	virtual ~OgreVRRender();
 
 	///Get the scene manager of the virtual world
-	Ogre::SceneManager* getSceneManager();
+	Ogre::SceneManager* getSceneManager() const;
 
 	///Get the Ogre::Root object
-	Ogre::Root* getRoot();
+	Ogre::Root* getRoot() const;
 
 	///Get the RenderWidow that should display a debug render the VR view
-	Ogre::RenderWindow* getWindow();
+	Ogre::RenderWindow* getWindow() const;
 
 	///Get the node that is the player's head anchor point
-	Ogre::SceneNode* getCameraInformationNode();
+	Ogre::SceneNode* getCameraInformationNode() const;
 
 	///Get Ogre's internal timer
-	Ogre::Timer* getTimer();
+	Ogre::Timer* getTimer() const;
 
 	///Get frame update time from the VR renderer
-	double getUpdateTime();
+	double getUpdateTime() const;
 
 	///Configure the Ogre root engine. Will load all the ogre Plug-ins and components we need.
-	void getOgreConfig();
+	void getOgreConfig() const;
 
 	///Init Ogre, please provide the name of the output log file
 	void initOgreRoot(std::string loggerName);
@@ -140,7 +147,7 @@ public:
 	virtual void showDebug(DebugMode mode) = 0;
 
 	///Get a naked array of hand controllers
-	std::array<std::shared_ptr<Annwvyn::AnnHandController>, MAX_CONTROLLER_NUMBER> getHandControllerArray();
+	std::array<std::shared_ptr<Annwvyn::AnnHandController>, MAX_CONTROLLER_NUMBER> getHandControllerArray() const;
 
 	///Get the size of the controller array
 	static size_t getHanControllerArraySize();
@@ -151,7 +158,7 @@ public:
 	virtual void handleIPDChange() = 0;
 
 	///Apply the position/orientation of the pose object to the camera rig
-	void applyCameraRigPose(OgrePose pose);
+	void applyCameraRigPose(OgrePose pose) const;
 
 	///extract from gameplay-movable information the points used to calculate the world poses
 	void syncGameplayBody();
@@ -161,13 +168,13 @@ public:
 	void calculateTimingFromOgre();
 
 	///Load "modern" OpenGL functions for the current OpenGL context.
-	void loadOpenGLFunctions();
+	static void loadOpenGLFunctions();
 
 	///This method create a texture with the wanted Anti Aliasing level. It will set the rttTexture and rttEyes member of this class to the correct value, and return the GLID of the texture.
 	unsigned int createRenderTexture(float w, float h);
 
 	///Create a render buffer with not anti aliasing. return a tuple with a TexturePtr and a GLID. use <code><pre>std::get<></pre></code>
-	std::tuple<Ogre::TexturePtr, unsigned int> createAdditionalRenderBuffer(float w, float h, std::string name = "");
+	std::tuple<Ogre::TexturePtr, unsigned int> createAdditionalRenderBuffer(float w, float h, std::string name = "") const;
 
 	void createWindow(unsigned int w = 1280, unsigned int h = 720, bool vsync = false);
 
@@ -179,7 +186,7 @@ protected:
 	std::string rendererName;
 
 	///Called if AA level has been updated
-	void changedAA();
+	void changedAA() const;
 
 	///Singleton pointer
 	static OgreVRRender* self;

--- a/include/OgreVRRender.hpp
+++ b/include/OgreVRRender.hpp
@@ -188,7 +188,7 @@ protected:
 	Ogre::SceneManager* smgr;
 
 	///Ogre root object
-	Ogre::Root* root;
+	std::unique_ptr<Ogre::Root> root;
 
 	///Render window. VR isn't drawn to this window. A window is mandatory to init the RenderSystem.
 	Ogre::RenderWindow* window;

--- a/src/AnnDefaultEventListener.cpp
+++ b/src/AnnDefaultEventListener.cpp
@@ -78,7 +78,7 @@ void AnnDefaultEventListener::KeyEvent(AnnKeyEvent e)
 	if (e.isPressed()) switch (e.getKey())
 	{
 		case KeyCode::grave:
-			AnnGetEngine()->toogleOnScreenConsole();
+			AnnGetOnScreenConsole()->toggle();
 			break;
 		case KeyCode::tab:
 			AnnGetVRRenderer()->cycleDebugHud();
@@ -124,7 +124,7 @@ void AnnDefaultEventListener::StickEvent(AnnStickEvent e)
 		player->run = false;
 
 	if (e.isPressed(buttons[b_console]))
-		AnnGetEngine()->toogleOnScreenConsole();
+		AnnGetOnScreenConsole()->toggle();
 	if (e.isPressed(buttons[b_debug]))
 		AnnGetVRRenderer()->cycleDebugHud();
 }
@@ -151,7 +151,7 @@ void AnnDefaultEventListener::HandControllerEvent(AnnHandControllerEvent e)
 			if (controller->hasBeenPressed(2))
 			{
 				if (controller->getType() == "Oculus Touch")
-					AnnGetEngine()->toogleOnScreenConsole();
+					AnnGetOnScreenConsole()->toggle();
 			}
 			break;
 		}

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -18,7 +18,6 @@ AnnEngineSingletonReseter::~AnnEngineSingletonReseter()
 }
 
 //Log is static. Therefore this has to be static too to be able to write to it.
-//std::shared_ptr<AnnConsole> AnnEngine::onScreenConsole(nullptr);
 WORD AnnEngine::consoleGreen(0);
 WORD AnnEngine::consoleYellow(0);
 WORD AnnEngine::consoleWhite(0);

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -14,7 +14,9 @@ AnnEngineSingletonReseter::AnnEngineSingletonReseter(AnnEngine* address)
 
 AnnEngineSingletonReseter::~AnnEngineSingletonReseter()
 {
+	//Reset static members of friend class AnnEnigine that will outlive the object itself.
 	engine->singleton = nullptr;
+	engine->consoleReady = false;
 }
 
 //Log is static. Therefore this has to be static too to be able to write to it.
@@ -45,6 +47,7 @@ void AnnEngine::startGameplayLoop()
 }
 
 AnnEngine::AnnEngine(const char title[], std::string hmdCommand) :
+	resetGuard(this),
 	renderer(nullptr),
 	resourceManager(nullptr),
 	sceneryManager(nullptr),
@@ -57,8 +60,7 @@ AnnEngine::AnnEngine(const char title[], std::string hmdCommand) :
 	player(nullptr),
 	SceneManager(nullptr),
 	vrRendererPovGameplayPlacement(nullptr),
-	updateTime(-1),
-	resetGuard(this)
+	updateTime(-1)
 {
 	if (singleton)
 	{
@@ -208,57 +210,57 @@ AnnEngine::~AnnEngine()
 //All theses getter are for encapsulation purpose. Calling them directly would
 //make very long lines of code. Note that there's a whole bunch of macro in
 //AnnEngine.hpp to help with that
-std::shared_ptr<AnnEventManager> AnnEngine::getEventManager()
+std::shared_ptr<AnnEventManager> AnnEngine::getEventManager() const
 {
 	return eventManager;
 }
 
-std::shared_ptr<AnnResourceManager> AnnEngine::getResourceManager()
+std::shared_ptr<AnnResourceManager> AnnEngine::getResourceManager() const
 {
 	return resourceManager;
 }
 
-std::shared_ptr<AnnGameObjectManager> AnnEngine::getGameObjectManager()
+std::shared_ptr<AnnGameObjectManager> AnnEngine::getGameObjectManager() const
 {
 	return gameObjectManager;
 }
 
-std::shared_ptr<AnnSceneryManager> AnnEngine::getSceneryManager()
+std::shared_ptr<AnnSceneryManager> AnnEngine::getSceneryManager() const
 {
 	return sceneryManager;
 }
 
-std::shared_ptr<AnnScriptManager> AnnEngine::getScriptManager()
+std::shared_ptr<AnnScriptManager> AnnEngine::getScriptManager() const
 {
 	return scriptManager;
 }
 
-std::shared_ptr<OgreVRRender> AnnEngine::getVRRenderer()
+std::shared_ptr<OgreVRRender> AnnEngine::getVRRenderer() const
 {
 	return renderer;
 }
 
-std::shared_ptr<AnnLevelManager> AnnEngine::getLevelManager()
+std::shared_ptr<AnnLevelManager> AnnEngine::getLevelManager() const
 {
 	return levelManager;
 }
 
-std::shared_ptr<AnnPlayer> AnnEngine::getPlayer()
+std::shared_ptr<AnnPlayer> AnnEngine::getPlayer() const
 {
 	return player;
 }
 
-std::shared_ptr<AnnFilesystemManager> AnnEngine::getFileSystemManager()
+std::shared_ptr<AnnFilesystemManager> AnnEngine::getFileSystemManager() const
 {
 	return filesystemManager;
 }
 
-std::shared_ptr<AnnAudioEngine> AnnEngine::getAudioEngine()
+std::shared_ptr<AnnAudioEngine> AnnEngine::getAudioEngine() const
 {
 	return audioEngine;
 }
 
-std::shared_ptr<AnnPhysicsEngine> AnnEngine::getPhysicsEngine()
+std::shared_ptr<AnnPhysicsEngine> AnnEngine::getPhysicsEngine() const
 {
 	return physicsEngine;
 }
@@ -288,13 +290,13 @@ void AnnEngine::log(std::string message, bool flag)
 
 //Don't ask me why this is not part of the Physics engine. Actually it just
 //calls something on the physics engine. Will be probably deleted in the future.
-void AnnEngine::initPlayerPhysics()
+void AnnEngine::initPlayerPhysics() const
 {
 	initPlayerStandingPhysics();
 }
 
 //Need to be redone.
-bool AnnEngine::requestStop()
+bool AnnEngine::requestStop() const
 {
 	//pres ESC to quit. Stupid but efficient. I like that.
 	if (isKeyDown(OIS::KC_ESCAPE))
@@ -335,7 +337,7 @@ bool AnnEngine::refresh()
 
 // This just move a node where the other node is. Yes I know about parenting.
 // I had reasons to do it that way, but I forgot.
-inline void AnnEngine::syncPov()
+inline void AnnEngine::syncPov() const
 {
 	vrRendererPovGameplayPlacement->setPosition(
 		player->getPosition());
@@ -344,34 +346,34 @@ inline void AnnEngine::syncPov()
 }
 
 //Bad. Don't use. Register an event listener and use the KeyEvent callback.
-inline bool AnnEngine::isKeyDown(OIS::KeyCode key)
+inline bool AnnEngine::isKeyDown(OIS::KeyCode key) const
 {
 	if (!eventManager) return false;
 	return eventManager->Keyboard->isKeyDown(key);
 }
 
-Ogre::SceneNode* AnnEngine::getPlayerPovNode()
+Ogre::SceneNode* AnnEngine::getPlayerPovNode() const
 {
 	return vrRendererPovGameplayPlacement;
 }
 
-Ogre::SceneManager* AnnEngine::getSceneManager()
+Ogre::SceneManager* AnnEngine::getSceneManager() const
 {
 	return SceneManager;
 }
 
-unsigned long AnnEngine::getTimeFromStartUp()
+unsigned long AnnEngine::getTimeFromStartUp() const
 {
 	return renderer->getTimer()->getMilliseconds();
 }
 
-double AnnEngine::getTimeFromStartupSeconds()
+double AnnEngine::getTimeFromStartupSeconds() const
 {
 	return double(getTimeFromStartUp()) / 1000.0;
 }
 
 //the delta time of the last frame, not the current one
-double AnnEngine::getFrameTime()
+double AnnEngine::getFrameTime() const
 {
 	return updateTime;
 }
@@ -379,7 +381,7 @@ double AnnEngine::getFrameTime()
 // Raw position and orientation of the head in world space. This is useful if
 // you want to mess around with weird stuff. This has been bodged when I
 // integrated a LEAP motion in that mess.
-OgrePose AnnEngine::getHmdPose()
+OgrePose AnnEngine::getHmdPose() const
 {
 	if (renderer)
 		return renderer->trackedHeadPose;
@@ -449,24 +451,24 @@ bool AnnEngine::openConsole()
 	return state;
 }
 
-bool AnnEngine::appVisibleInHMD()
+bool AnnEngine::appVisibleInHMD() const
 {
 	if (renderer->isVisibleInHmd())
 		return true;
 	return false;
 }
 
-void AnnEngine::initPlayerStandingPhysics()
+void AnnEngine::initPlayerStandingPhysics() const
 {
 	physicsEngine->initPlayerStandingPhysics(vrRendererPovGameplayPlacement);
 }
 
-void AnnEngine::initPlayerRoomscalePhysics()
+void AnnEngine::initPlayerRoomscalePhysics() const
 {
 	physicsEngine->initPlayerRoomscalePhysics(vrRendererPovGameplayPlacement);
 }
 
-std::shared_ptr<AnnConsole> AnnEngine::getOnScreenConsole()
+std::shared_ptr<AnnConsole> AnnEngine::getOnScreenConsole() const
 {
 	return onScreenConsole;
 }

--- a/src/OgreNoVRRender.cpp
+++ b/src/OgreNoVRRender.cpp
@@ -105,5 +105,5 @@ OgreNoVRRender::~OgreNoVRRender()
 	rttTexture.setNull();
 
 	//TODO here, and only here, there's a crash when unloading a font, probably the one declared by AnnConsole. Makes no sense. Will investigate.
-	//delete root;
+	delete root;
 }

--- a/src/OgreNoVRRender.cpp
+++ b/src/OgreNoVRRender.cpp
@@ -103,7 +103,4 @@ OgreNoVRRender::~OgreNoVRRender()
 	root->destroySceneManager(smgr);
 	noVRself = nullptr;
 	rttTexture.setNull();
-
-	//TODO here, and only here, there's a crash when unloading a font, probably the one declared by AnnConsole. Makes no sense. Will investigate.
-	delete root;
 }

--- a/src/OgreOculusRender.cpp
+++ b/src/OgreOculusRender.cpp
@@ -70,8 +70,6 @@ OgreOculusRender::~OgreOculusRender()
 	//Release shared pointers from Ogre before deleting Root
 	DebugPlaneMaterial.setNull();
 	rttTexture.setNull();
-
-	//delete root;
 }
 
 bool OgreOculusRender::shouldQuit()

--- a/src/OgreOculusRender.cpp
+++ b/src/OgreOculusRender.cpp
@@ -71,7 +71,7 @@ OgreOculusRender::~OgreOculusRender()
 	DebugPlaneMaterial.setNull();
 	rttTexture.setNull();
 
-	delete root;
+	//delete root;
 }
 
 bool OgreOculusRender::shouldQuit()

--- a/src/OgreOculusRender.cpp
+++ b/src/OgreOculusRender.cpp
@@ -152,7 +152,7 @@ void OgreOculusRender::initVrHmd()
 	AnnDebug() << "Eye leveling translation : " << AnnGetPlayer()->getEyeTranslation();
 }
 
-void OgreOculusRender::setMonoFov(float degreeFov)
+void OgreOculusRender::setMonoFov(float degreeFov) const
 {
 	if (monoCam) monoCam->setFOVy(Ogre::Degree(degreeFov));
 }

--- a/src/OgreOpenVRRender.cpp
+++ b/src/OgreOpenVRRender.cpp
@@ -62,7 +62,7 @@ OgreOpenVRRender::~OgreOpenVRRender()
 
 	rttTexture.setNull();
 
-	delete root;
+	//delete root;
 }
 
 //This function is from VALVe

--- a/src/OgreOpenVRRender.cpp
+++ b/src/OgreOpenVRRender.cpp
@@ -61,8 +61,6 @@ OgreOpenVRRender::~OgreOpenVRRender()
 	root->destroySceneManager(smgr);
 
 	rttTexture.setNull();
-
-	//delete root;
 }
 
 //This function is from VALVe

--- a/src/OgreVRRender.cpp
+++ b/src/OgreVRRender.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "OgreVRRender.hpp"
 #include "AnnGetter.hpp"
-#include "../include/AnnLogger.hpp"
+#include "AnnLogger.hpp"
 
 uint8_t OgreVRRender::AALevel{ 4 };
 OgreVRRender* OgreVRRender::self{ nullptr };
@@ -20,22 +20,22 @@ void OgreVRRender::setAntiAliasingLevel(const uint8_t AA)
 }
 
 OgreVRRender::OgreVRRender(std::string windowName) :
-	smgr(nullptr),
-	root(nullptr),
-	window(nullptr),
-	updateTime(0),
-	nearClippingDistance(0.1f),
-	farClippingDistance(500.0f),
-	feetPosition(0, 0, 10),
-	bodyOrientation(Ogre::Quaternion::IDENTITY),
-	name(windowName),
-	gameplayCharacterRoot(nullptr),
-	backgroundColor(0, 0.56f, 1),
+	smgr{ nullptr },
+	root{ nullptr },
+	window{ nullptr },
+	updateTime{ 0 },
+	then{ 0 },
+	now{ 0 },
+	nearClippingDistance{ 0.1f },
+	farClippingDistance{ 500.0f },
+	feetPosition{ 0, 0, 10 },
+	bodyOrientation{ Ogre::Quaternion::IDENTITY },
+	name{ windowName },
+	gameplayCharacterRoot{ nullptr },
+	backgroundColor{ 0, 0.56f, 1 },
 	cameraRig{ nullptr },
-	frameCounter(0),
-	rttEyes(nullptr),
-	then(0),
-	now(0)
+	frameCounter{ 0 },
+	rttEyes{ nullptr }
 {
 	rttTexture.setNull();
 	if (self)
@@ -57,33 +57,33 @@ OgreVRRender::~OgreVRRender()
 	root->unloadPlugin("Plugin_OctreeSceneManager");
 }
 
-Ogre::SceneManager* OgreVRRender::getSceneManager()
+Ogre::SceneManager* OgreVRRender::getSceneManager() const
 {
 	return smgr;
 }
 
-Ogre::Root* OgreVRRender::getRoot()
+Ogre::Root* OgreVRRender::getRoot() const
 {
 	return root.get();
 }
 
-Ogre::RenderWindow* OgreVRRender::getWindow()
+Ogre::RenderWindow* OgreVRRender::getWindow() const
 {
 	return window;
 }
 
-Ogre::SceneNode* OgreVRRender::getCameraInformationNode()
+Ogre::SceneNode* OgreVRRender::getCameraInformationNode() const
 {
 	return gameplayCharacterRoot;
 }
 
-Ogre::Timer * OgreVRRender::getTimer()
+Ogre::Timer * OgreVRRender::getTimer() const
 {
 	if (root) return root->getTimer();
 	return nullptr;
 }
 
-double OgreVRRender::getUpdateTime()
+double OgreVRRender::getUpdateTime() const
 {
 	return updateTime;
 }
@@ -97,23 +97,23 @@ void OgreVRRender::initOgreRoot(std::string loggerName)
 	Ogre::LogManager::getSingleton().setLogDetail(Ogre::LoggingLevel::LL_BOREME);
 }
 
-void OgreVRRender::getOgreConfig()
+void OgreVRRender::getOgreConfig() const
 {
 	//Ogre as to be initialized
 	if (!root) throw std::runtime_error("Error : " + std::to_string(ANN_ERR_NOTINIT) + "Need to initialize Ogre::Root before loading system configuration");
 
 	//Load OgrePlugins
-	root->loadPlugin("RenderSystem_GL");
-	root->loadPlugin("Plugin_OctreeSceneManager");
+	root->loadPlugin(PluginRenderSystemGL);
+	root->loadPlugin(PluginOctreeSceneManager);
 
 	//Set the classic OpenGL render system
-	root->setRenderSystem(root->getRenderSystemByName("OpenGL Rendering Subsystem"));
+	root->setRenderSystem(root->getRenderSystemByName(GLRenderSystem));
 	root->getRenderSystem()->setFixedPipelineEnabled(true);
 	root->getRenderSystem()->setConfigOption("RTT Preferred Mode", "FBO");
 	root->getRenderSystem()->setConfigOption("FSAA", std::to_string(AALevel));
 }
 
-std::array<std::shared_ptr<Annwvyn::AnnHandController>, MAX_CONTROLLER_NUMBER> OgreVRRender::getHandControllerArray()
+std::array<std::shared_ptr<Annwvyn::AnnHandController>, MAX_CONTROLLER_NUMBER> OgreVRRender::getHandControllerArray() const
 {
 	return handControllers;
 }
@@ -132,7 +132,7 @@ size_t OgreVRRender::getRecognizedControllerCount()
 	return count;
 }
 
-void OgreVRRender::changedAA()
+void OgreVRRender::changedAA() const
 {
 	if (rttTexture.getPointer() && !UseSSAA) rttTexture->setFSAA(AALevel, "");
 }
@@ -173,7 +173,7 @@ void OgreVRRender::initCameras()
 	gameplayCharacterRoot = smgr->getRootSceneNode()->createChildSceneNode();
 }
 
-void OgreVRRender::applyCameraRigPose(OgrePose pose)
+void OgreVRRender::applyCameraRigPose(OgrePose pose) const
 {
 	cameraRig->setPosition(pose.position);
 	cameraRig->setOrientation(pose.orientation);
@@ -209,9 +209,7 @@ void OgreVRRender::loadOpenGLFunctions()
 void OgreVRRender::updateTracking()
 {
 	syncGameplayBody();
-
 	getTrackingPoseAndVRTiming();
-
 	applyCameraRigPose(trackedHeadPose);
 }
 
@@ -235,7 +233,7 @@ GLuint OgreVRRender::createRenderTexture(float w, float h)
 	return glid;
 }
 
-std::tuple<Ogre::TexturePtr, unsigned int> OgreVRRender::createAdditionalRenderBuffer(float w, float h, std::string additionalTextureName)
+std::tuple<Ogre::TexturePtr, unsigned int> OgreVRRender::createAdditionalRenderBuffer(float w, float h, std::string additionalTextureName) const
 {
 	static int counter;
 	if (additionalTextureName.empty())

--- a/src/OgreVRRender.cpp
+++ b/src/OgreVRRender.cpp
@@ -65,7 +65,7 @@ Ogre::SceneManager* OgreVRRender::getSceneManager()
 
 Ogre::Root* OgreVRRender::getRoot()
 {
-	return root;
+	return root.get();
 }
 
 Ogre::RenderWindow* OgreVRRender::getWindow()
@@ -92,7 +92,7 @@ double OgreVRRender::getUpdateTime()
 void OgreVRRender::initOgreRoot(std::string loggerName)
 {
 	//Create the ogre root with standards Ogre configuration file
-	root = new Ogre::Root("", "ogre.cfg", loggerName.c_str());
+	root = std::make_unique<Ogre::Root>("", "ogre.cfg", loggerName.c_str());
 
 	//Set the log verbosity to "bore me"
 	Ogre::LogManager::getSingleton().setLogDetail(Ogre::LoggingLevel::LL_BOREME);

--- a/src/OgreVRRender.cpp
+++ b/src/OgreVRRender.cpp
@@ -55,7 +55,6 @@ OgreVRRender::~OgreVRRender()
 {
 	self = nullptr;
 	root->unloadPlugin("Plugin_OctreeSceneManager");
-	//delete root;
 }
 
 Ogre::SceneManager* OgreVRRender::getSceneManager()


### PR DESCRIPTION
…n thanks to some scope bound memory management + fix console deletion

should fix #57 and #58 

Still have some testing but this PR does : 

 - Introduce a small object that serve as a "reset guard" for the singleton member of AnnEngine, fixing #57, and raising the #58 problem
 - Stop storing the onScreenConsole into a... **ahem**, a... *static shared pointer*... (I know, I know) that fixes #58

This also makes the no-vr renderer actually destroy the Ogre::Root object when it's done, like the others. The root object should be movable to an unique_ptr, making this problem non-existent now.

Subsequent commit here will be added to clean up this, test and verify that everything is still in order before merging this to master. 

This was simpler than expected, and it's 2AM.
