### PR TITLE
Make the AnnEngine constructor set the main process priority to high

### DIFF
--- a/include/AnnEngine.hpp
+++ b/include/AnnEngine.hpp
@@ -86,6 +86,10 @@ namespace Annwvyn
 
 	public:
 
+		static bool autosetProcessPriorityHigh;
+		static void setProcessPriorityNormal();
+		static void setProcessPriorityHigh();
+
 		///Get the current instance of AnnEngine. pointer
 		static AnnEngine* Instance();
 

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -491,10 +491,14 @@ std::shared_ptr<AnnStringUility> AnnEngine::getStringUtility() const
 
 void AnnEngine::setProcessPriorityNormal()
 {
+#ifdef _WIN32
 	SetPriorityClass(GetCurrentProcess(), NORMAL_PRIORITY_CLASS);
+#endif
 }
 
 void AnnEngine::setProcessPriorityHigh()
 {
+#ifdef _WIN32
 	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
+#endif
 }

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -70,6 +70,13 @@ AnnEngine::AnnEngine(const char title[], std::string hmdCommand) :
 
 	stringUtility = std::make_shared<AnnStringUility>();
 
+#ifdef _WIN32
+	//Set current process to high priority.
+	//Looks like the scheduler of Windows sometimes don't give use the time we need to be consistent.
+	//This seems to fixes the problem.
+	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
+#endif
+
 	consoleReady = false;
 
 	std::cerr << "HMD selection from command line routine returned : "

--- a/src/AnnEngine.cpp
+++ b/src/AnnEngine.cpp
@@ -6,6 +6,7 @@ using namespace Annwvyn;
 
 AnnEngine* AnnEngine::singleton(nullptr);
 bool AnnEngine::consoleReady(false);
+bool AnnEngine::autosetProcessPriorityHigh(true);
 
 AnnEngineSingletonReseter::AnnEngineSingletonReseter(AnnEngine* address)
 {
@@ -74,7 +75,8 @@ AnnEngine::AnnEngine(const char title[], std::string hmdCommand) :
 	//Set current process to high priority.
 	//Looks like the scheduler of Windows sometimes don't give use the time we need to be consistent.
 	//This seems to fixes the problem.
-	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
+	if (autosetProcessPriorityHigh)
+		setProcessPriorityHigh();
 #endif
 
 	consoleReady = false;
@@ -485,4 +487,14 @@ std::shared_ptr<AnnConsole> AnnEngine::getOnScreenConsole() const
 std::shared_ptr<AnnStringUility> AnnEngine::getStringUtility() const
 {
 	return stringUtility;
+}
+
+void AnnEngine::setProcessPriorityNormal()
+{
+	SetPriorityClass(GetCurrentProcess(), NORMAL_PRIORITY_CLASS);
+}
+
+void AnnEngine::setProcessPriorityHigh()
+{
+	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
 }

--- a/src/AnnScriptManager.cpp
+++ b/src/AnnScriptManager.cpp
@@ -324,8 +324,11 @@ void AnnScriptManager::registerApi()
 	chai.add(fun([](int i) {AnnDebug() << logFromScript << "int:" << i; }), "AnnDebugLog");
 	chai.add(fun([](float f) {AnnDebug() << logFromScript << "float:" << f; }), "AnnDebugLog");
 
-	///Clear the console 
+	///Clear the console
 	chai.add(fun([]() {AnnGetOnScreenConsole()->bufferClear(); }), "AnnClearConsole");
+
+	chai.add(fun([]() {AnnEngine::setProcessPriorityHigh(); }), "AnnSetProcessPriorityHigh");
+	chai.add(fun([]() {AnnEngine::setProcessPriorityNormal(); }), "AnnSetProcessPriorityNormal");
 }
 
 void AnnScriptManager::tryAndGetEventHooks()


### PR DESCRIPTION
This seems to fix some issues, but I'm not sure if it's a good idea to
mess with the Window's users CPU scheduler.

Fix #78,  but may be changed to be user switchable. 