### PR TITLE
Adjust the initialization of the script manager for chai6

### DIFF
--- a/msvc/Annwvyn/Annwvyn.sln
+++ b/msvc/Annwvyn/Annwvyn.sln
@@ -33,7 +33,6 @@ Global
 		{18C4D2EE-11C7-4CC0-9916-B910D07A1F2B}.Debug|x64.ActiveCfg = Debug|x64
 		{18C4D2EE-11C7-4CC0-9916-B910D07A1F2B}.Debug|x64.Build.0 = Debug|x64
 		{18C4D2EE-11C7-4CC0-9916-B910D07A1F2B}.Release|x64.ActiveCfg = Release|x64
-		{18C4D2EE-11C7-4CC0-9916-B910D07A1F2B}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/msvc/Annwvyn/Annwvyn.vcxproj
+++ b/msvc/Annwvyn/Annwvyn.vcxproj
@@ -157,7 +157,7 @@ COPY "$(TargetDir)\Annwvyn.pdb" "$(TargetDir)\..\template\"
       <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
       <FloatingPointModel>Fast</FloatingPointModel>
       <MinimalRebuild>false</MinimalRebuild>
-      <TreatWarningAsError>true</TreatWarningAsError>
+      <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/AnnScriptManager.cpp
+++ b/src/AnnScriptManager.cpp
@@ -9,14 +9,13 @@
 
 using namespace Annwvyn;
 
-AnnScriptManager::AnnScriptManager() : AnnSubSystem("ScriptManager"),
+AnnScriptManager::AnnScriptManager() : AnnSubSystem("ScriptManager")
 //Initialize with compiled-in Std_Lib
-chai(chaiscript::Std_Lib::library())
 {
 	AnnDebug() << "Initialized ChaiScript Std_Lib";
 	registerApi();
 
-	AnnDebug() << "Using ChaiScript version : " << chai.version();
+	AnnDebug() << "Using ChaiScript version 6.0";
 }
 
 void AnnScriptManager::registerApi()


### PR DESCRIPTION
Remove /wx from the compilation options

Fix #95 